### PR TITLE
Bug: EPNL=-inf if PNLT remains above Decay after PNLT_idx

### DIFF
--- a/psychoacoustic_metrics/EPNL_FAR_Part36/helper/get_Duration_Correction.m
+++ b/psychoacoustic_metrics/EPNL_FAR_Part36/helper/get_Duration_Correction.m
@@ -61,6 +61,11 @@ idx_t1 = find( PNLT(1:PNLTM_idx)>Decay, K ); % idx_t1 is the first point where P
 idx_t2 = find( PNLT(PNLTM_idx:end)<Decay, K); % idx_t2 is the first point where PNLT becomes <(PNLTM - threshold)
 idx_t2 = idx_t2 + (PNLTM_idx-1); % correct for PNLTM_idx number because full vector is trimmed in the previous line
 
+% if case for idx_t2 not found (PNLT never becomes lower than Decay)
+if isempty(idx_t2)
+    idx_t2 = size(PNLT, 1);  % take idx_t2 as last index in PNLT
+end
+
 % Calculate duration correction factor
 D = 10*log10(sum(10.^(PNLT(idx_t1:idx_t2)/10))) - PNLTM + 10*log10(dt/10);
 

--- a/psychoacoustic_metrics/EPNL_FAR_Part36/helper/get_Duration_Correction.m
+++ b/psychoacoustic_metrics/EPNL_FAR_Part36/helper/get_Duration_Correction.m
@@ -64,6 +64,7 @@ idx_t2 = idx_t2 + (PNLTM_idx-1); % correct for PNLTM_idx number because full vec
 % if case for idx_t2 not found (PNLT never becomes lower than Decay)
 if isempty(idx_t2)
     idx_t2 = size(PNLT, 1);  % take idx_t2 as last index in PNLT
+	warning("The signal does not decay by more than the threshold within the available duration. An indicative EPNL value is calculated from the available duration, but should not be used for aircraft noise certification.");
 end
 
 % Calculate duration correction factor


### PR DESCRIPTION
If the remaining values in PNLT after PNLT(PNLT_idx) do not drop below the value of Decay, idx_t2 returns empty and the duration correction cannot be completed, resulting in EPNL = -inf.

In this case, a reasonable fix is to take the last index of PNLT as idx_t2.