### PR TITLE
Bandsharing

### DIFF
--- a/psychoacoustic_metrics/EPNL_FAR_Part36/helper/get_Duration_Correction.m
+++ b/psychoacoustic_metrics/EPNL_FAR_Part36/helper/get_Duration_Correction.m
@@ -61,12 +61,6 @@ idx_t1 = find( PNLT(1:PNLTM_idx)>Decay, K ); % idx_t1 is the first point where P
 idx_t2 = find( PNLT(PNLTM_idx:end)<Decay, K); % idx_t2 is the first point where PNLT becomes <(PNLTM - threshold)
 idx_t2 = idx_t2 + (PNLTM_idx-1); % correct for PNLTM_idx number because full vector is trimmed in the previous line
 
-% if case for idx_t2 not found (PNLT never becomes lower than Decay)
-if isempty(idx_t2)
-    idx_t2 = size(PNLT, 1);  % take idx_t2 as last index in PNLT
-	warning("The signal does not decay by more than the threshold within the available duration. An indicative EPNL value is calculated from the available duration, but should not be used for aircraft noise certification.");
-end
-
 % Calculate duration correction factor
 D = 10*log10(sum(10.^(PNLT(idx_t1:idx_t2)/10))) - PNLTM + 10*log10(dt/10);
 

--- a/psychoacoustic_metrics/EPNL_FAR_Part36/helper/get_Duration_Correction.m
+++ b/psychoacoustic_metrics/EPNL_FAR_Part36/helper/get_Duration_Correction.m
@@ -61,6 +61,11 @@ idx_t1 = find( PNLT(1:PNLTM_idx)>Decay, K ); % idx_t1 is the first point where P
 idx_t2 = find( PNLT(PNLTM_idx:end)<Decay, K); % idx_t2 is the first point where PNLT becomes <(PNLTM - threshold)
 idx_t2 = idx_t2 + (PNLTM_idx-1); % correct for PNLTM_idx number because full vector is trimmed in the previous line
 
+% if case for idx_t2 not found (PNLT never becomes lower than Decay)
+if isempty(idx_t2)
+    idx_t2 = size(PNLT, 1);  % take idx_t2 as last index in PNLT
+end
+
 % Calculate duration correction factor
 D = 10*log10(sum(10.^(PNLT(idx_t1:idx_t2)/10))) - PNLTM + 10*log10(dt/10);
 

--- a/psychoacoustic_metrics/EPNL_FAR_Part36/helper/get_Duration_Correction.m
+++ b/psychoacoustic_metrics/EPNL_FAR_Part36/helper/get_Duration_Correction.m
@@ -64,6 +64,7 @@ idx_t2 = idx_t2 + (PNLTM_idx-1); % correct for PNLTM_idx number because full vec
 % if case for idx_t2 not found (PNLT never becomes lower than Decay)
 if isempty(idx_t2)
     idx_t2 = size(PNLT, 1);  % take idx_t2 as last index in PNLT
+	warning("The signal does not decay by more than the threshold within the available duration. An indicative EPNL value is calculated from the available duration, but should not be used for aircraft noise certification.");
 end
 
 % Calculate duration correction factor

--- a/psychoacoustic_metrics/EPNL_FAR_Part36/helper/get_PNLT.m
+++ b/psychoacoustic_metrics/EPNL_FAR_Part36/helper/get_PNLT.m
@@ -204,6 +204,20 @@ end
 
 [PNLTM,PNLTM_idx] = max(PNLT); % MAXIMUM TONE-CORRECTED PERCEIVED NOISE LEVEL (PNLTM)
 
+%% Bandsharing adjustment to PNLTM
+
+Cavg = sum([Cmax(PNLTM_idx - 2), Cmax(PNLTM_idx - 1), Cmax(PNLTM_idx),...
+            Cmax(PNLTM_idx + 1), Cmax(PNLTM_idx + 2)])/5;
+
+if Cavg > Cmax(PNLTM_idx)
+    DeltaB = Cavg*Cmax(PNLTM_idx);
+else
+    DeltaB = 0;
+end
+
+% apply adjustment
+PNLTM = PNLTM + DeltaB;
+
 %% Output variables for verification of the tone correction implementation
 
 OUT.S = S;


### PR DESCRIPTION
Added an enhancement to include the procedure for adjusting the PNLTM in cases where 'bandsharing' is detected: if the PNLT tone adjustment Cmax matches a criterion based on the average adjustment value over the preceding and succeeding 2 values of C(k), a further adjustment is made to the PNLTM.

As described in paragraphs 4.4.1-4.4.3 of Appendix 2 to ICAO Annex 16 Volume 1 (8th edition, 2017, amended 2021).