### PR TITLE
ECMA-418-2 roughness amends - peak pick and output length

### DIFF
--- a/psychoacoustic_metrics/Roughness_ECMA418_2/Roughness_ECMA418_2.m
+++ b/psychoacoustic_metrics/Roughness_ECMA418_2/Roughness_ECMA418_2.m
@@ -66,11 +66,11 @@ function OUT = Roughness_ECMA418_2(insig, fs, fieldtype, time_skip, show)
 %                 arranged as [time(, channels)]
 %
 % roughness90Pc : number or vector
-%                             90th percentile (a.k.a. value exceeded 10% of the time) 
-%                             of the time-dependent roughness. According to 
-%                             ECMA-418-2:2024 (Section 7.1.10), this quantity must be used as 
-%                             as the representative single value (overall roughness).               
-%                             OBS: takes <time_skip> into consideration
+%                 90th percentile (a.k.a. value exceeded 10% of the time) 
+%                 of the time-dependent roughness. According to 
+%                 ECMA-418-2:2024 (Section 7.1.10), this quantity must be used as 
+%                 as the representative single value (overall roughness).               
+%                 OBS: takes <time_skip> into consideration
 %
 % bandCentreFreqs : vector
 %                   centre frequencies corresponding with each (half)
@@ -115,11 +115,11 @@ function OUT = Roughness_ECMA418_2(insig, fs, fieldtype, time_skip, show)
 %                 arranged as [time]
 %
 % roughness90PcBin : number
-%                             90th percentile (a.k.a. value exceeded 10% of the time) 
-%                             of the time-dependent roughness. According to 
-%                             ECMA-418-2:2024 (Section 7.1.10), this quantity must be used as 
-%                              the representative single value (overall roughness).  
-%                             OBS: takes <time_skip> into consideration.
+%                    90th percentile (a.k.a. value exceeded 10% of the time) 
+%                    of the time-dependent roughness. According to 
+%                    ECMA-418-2:2024 (Section 7.1.10), this quantity must be used as 
+%                    the representative single value (overall roughness).  
+%                    OBS: takes <time_skip> into consideration.
 %
 % If show==true, a set of plots is returned illustrating the energy
 % time-averaged A-weighted sound level, the time-dependent specific and
@@ -145,7 +145,7 @@ function OUT = Roughness_ECMA418_2(insig, fs, fieldtype, time_skip, show)
 % Institution: University of Salford
 %
 % Date created: 12/10/2023
-% Date last modified: 09/01/2025
+% Date last modified: 03/02/2025
 % MATLAB version: 2023b
 %
 % Copyright statement: This file and code is part of work undertaken within
@@ -164,7 +164,7 @@ function OUT = Roughness_ECMA418_2(insig, fs, fieldtype, time_skip, show)
 % information.
 %
 % Checked by: Gil Felix Greco
-% Date last checked: 17.01.2025
+% Date last checked: 04.02.2025
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% Arguments validation
     arguments (Input) % Matlab R2018b or newer
@@ -401,13 +401,18 @@ for chan = size(pn_om, 2):-1:1
         % Section 7.1.5.1 ECMA-418-2:2024
         for lBlock = nBlocks:-1:1
             % identify peaks in each block (for each band)
-            [PhiPks, kLocs, ~, proms] = findpeaks(modWeightSpectraAvg(3:256,...
+            [PhiPks, kLocs, ~, proms] = findpeaks(modWeightSpectraAvg(1 + mlabIndex:256,...
                                                                       lBlock,...
                                                                       zBand));
 
             % reindex kLocs to match spectral start index used in findpeaks
             % for indexing into modulation spectra matrices
-            kLocs = kLocs + 2;
+            kLocs = kLocs + mlabIndex;
+
+            % we cannot have a peak at k=1
+            mask = kLocs ~= 1 + mlabIndex;
+            kLocs = kLocs(mask);
+            PhiPks = PhiPks(mask);
 
             % consider 10 highest prominence peaks only
             if length(proms) > 10
@@ -609,9 +614,9 @@ for chan = size(pn_om, 2):-1:1
 
     % interpolation to 50 Hz sampling rate
     % Section 7.1.7 Equation 103 [l_50,end]
-    l_50 = floor(n_samples/sampleRate48k*sampleRate50);
-    x = (iBlocks - 1)/fs;
-    xq = linspace(0, signalT - 1/sampleRate50, l_50);
+    l_50Last = floor(n_samples/sampleRate48k*sampleRate50) + 1;
+    x = (iBlocks - 1)/sampleRatein;
+    xq = linspace(0, signalT, l_50Last);
     for zBand = nBands:-1:1
         specRoughEst(:, zBand) = pchip(x, modAmpMax(:, zBand), xq);
     end  % end of for loop for interpolation


### PR DESCRIPTION
The amendments address:

1. the peak-picking procedure to enable a peak at k=2 to be selected (by including k=1 in the peak search and later removing any k=1 result)
2. the inadvertent truncation of the output by 1 sample
