### PR TITLE
ECMA-418-2:2025 tweaks

### DIFF
--- a/psychoacoustic_metrics/Loudness_ECMA418_2/LoudnessFromComp_ECMA418_2.m
+++ b/psychoacoustic_metrics/Loudness_ECMA418_2/LoudnessFromComp_ECMA418_2.m
@@ -130,7 +130,7 @@ function OUT = LoudnessFromComp_ECMA418_2(specTonalLoudness, specNoiseLoudness, 
 % Institution: University of Salford
 %
 % Date created: 22/08/2023
-% Date last modified: 27/06/2025
+% Date last modified: 23/07/2025
 % MATLAB version: 2023b
 %
 % Copyright statement: This file and code is part of work undertaken within
@@ -199,6 +199,9 @@ b = 0.5459;
 % ECMA-418-2:2025) [r_sd]
 sampleRate1875 = sampleRate48k/256;
 
+% Footnote 14 standardised epsilon
+epsilon = 1e-12;
+
 %% Signal processing
 
 % get time block vector of input signal
@@ -210,7 +213,7 @@ for chan = chansIn:-1:1
     % Equation 114 ECMA-418-2:2025 [e(z)]
     maxLoudnessFuncel = a./(max(specTonalLoudness(:, :, chan)...
                                 + specNoiseLoudness(:, :, chan), [],...
-                                2, "omitnan") + 1e-12) + b;
+                                2, "omitnan") + epsilon) + b;
     % Equation 113 ECMA-418-2:2025 [N'(l,z)]
     specLoudness(:, :, chan) = (specTonalLoudness(:, :, chan).^maxLoudnessFuncel...
                                     + abs((weight_n.*specNoiseLoudness(:, :, chan)).^maxLoudnessFuncel)).^(1./maxLoudnessFuncel);
@@ -219,9 +222,9 @@ end
 if chansIn == 2
     % Binaural loudness
     % Section 8.1.5 ECMA-418-2:2025 Equation 118 [N'_B(l,z)]
-    specLoudness(:, :, 3) = sqrt(sum(specLoudness.^2, 3)/2);
-    specTonalLoudness(:, :, 3) = sqrt(sum(specTonalLoudness.^2, 3)/2);
-    specNoiseLoudness(:, :, 3) = sqrt(sum(specNoiseLoudness.^2, 3)/2);
+    specLoudness(:, :, 3) = sqrt(sum(specLoudness(:, :, 1:2).^2, 3)/2);
+    specTonalLoudness(:, :, 3) = sqrt(sum(specTonalLoudness(:, :, 1:2).^2, 3)/2);
+    specNoiseLoudness(:, :, 3) = sqrt(sum(specNoiseLoudness(:, :, 1:2).^2, 3)/2);
     chansOut = 3;  % set number of 'channels' to stereo plus single binaural
     chans = [chans;
              "Combined binaural"];

--- a/psychoacoustic_metrics/Loudness_ECMA418_2/Loudness_ECMA418_2.m
+++ b/psychoacoustic_metrics/Loudness_ECMA418_2/Loudness_ECMA418_2.m
@@ -142,7 +142,7 @@ function OUT = Loudness_ECMA418_2(insig, fs, fieldtype, time_skip, show)
 % Institution: University of Salford
 %
 % Date created: 22/09/2023
-% Date last modified: 27/06/2025
+% Date last modified: 23/07/2025
 % MATLAB version: 2023b
 %
 % Copyright statement: This file and code is part of work undertaken within
@@ -231,6 +231,9 @@ b = 0.5459;
 % ECMA-418-2:2025) [r_sd]
 sampleRate1875 = sampleRate48k/256;
 
+% Footnote 14 standardised epsilon
+epsilon = 1e-12;
+
 %% Signal processing
 
 % get time vector of input signal
@@ -260,7 +263,7 @@ for chan = chansIn:-1:1
     % Equation 114 ECMA-418-2:2025 [e(z)]
     maxLoudnessFuncel = a./(max(specTonalLoudness(:, :, chan)...
                                 + specNoiseLoudness(:, :, chan), [],...
-                                2, "omitnan") + 1e-12) + b;
+                                2, "omitnan") + epsilon) + b;
 
     % Equation 113 ECMA-418-2:2025 [N'(l,z)]
     specLoudness(:, :, chan) = (specTonalLoudness(:, :, chan).^maxLoudnessFuncel...
@@ -270,9 +273,9 @@ end
 if chansIn == 2 && binaural
     % Binaural loudness
     % Section 8.1.5 ECMA-418-2:2025 Equation 118 [N'_B(l,z)]
-    specLoudness(:, :, 3) = sqrt(sum(specLoudness.^2, 3)/2);
-    specTonalLoudness(:, :, 3) = sqrt(sum(specTonalLoudness.^2, 3)/2);
-    specNoiseLoudness(:, :, 3) = sqrt(sum(specNoiseLoudness.^2, 3)/2);
+    specLoudness(:, :, 3) = sqrt(sum(specLoudness(:, :, 1:2).^2, 3)/2);
+    specTonalLoudness(:, :, 3) = sqrt(sum(specTonalLoudness(:, :, 1:2).^2, 3)/2);
+    specNoiseLoudness(:, :, 3) = sqrt(sum(specNoiseLoudness(:, :, 1:2).^2, 3)/2);
     chansOut = 3;  % set number of 'channels' to stereo plus single binaural
     chans = [chans;
              "Combined binaural"];

--- a/psychoacoustic_metrics/Roughness_ECMA418_2/Roughness_ECMA418_2.m
+++ b/psychoacoustic_metrics/Roughness_ECMA418_2/Roughness_ECMA418_2.m
@@ -145,7 +145,7 @@ function OUT = Roughness_ECMA418_2(insig, fs, fieldtype, time_skip, show)
 % Institution: University of Salford
 %
 % Date created: 12/10/2023
-% Date last modified: 27/06/2025
+% Date last modified: 23/07/2025
 % MATLAB version: 2023b
 %
 % Copyright statement: This file and code is part of work undertaken within
@@ -279,6 +279,9 @@ sampleRate50 = 50;
 % Calibration constant
 cal_R = 0.0180909;   % calibration factor in Section 7.1.7 Equation 104 ECMA-418-2:2025 [c_R]
 cal_Rx = 1/1.0011565;  % calibration adjustment factor
+
+% Footnote 14 standardised epsilon
+epsilon = 1e-12;
 
 %% Signal processing
 
@@ -584,7 +587,7 @@ for chan = size(pn_om, 2):-1:1
                 % Equation 93 [w_peak]
                 gravityWeight = 1 + 0.1*abs(sum(modRateForLoop(indSetMax)...
                                             .*modAmpHiWeight(indSetMax, lBlock, zBand))...
-                                            /sum(modAmpHiWeight(indSetMax, lBlock, zBand) + eps)...
+                                            /sum(modAmpHiWeight(indSetMax, lBlock, zBand) + epsilon)...
                                             - modRateForLoop(iPeak)).^0.749;
 
                 % Equation 92 [Ahat(i)]
@@ -651,7 +654,7 @@ end  % end of for loop over channels
 % Binaural roughness
 % Section 7.1.11 ECMA-418-2:2025 [R'_B(l_50,z)]
 if chansIn == 2 && binaural
-    specRoughness(:, :, 3) = sqrt(sum(specRoughness.^2, 3)/2);  % Equation 112
+    specRoughness(:, :, 3) = sqrt(sum(specRoughness(:, :, 1:2).^2, 3)/2);  % Equation 112
     chansOut = 3;  % set number of 'channels' to stereo plus single binaural
     chans = [chans;
              "Combined binaural"];
@@ -682,7 +685,7 @@ end
 
 % Section 7.1.10 ECMA-418-2:2025
 % Overall roughness [R]
-roughness90Pc = prctile(roughnessTDep(time_skip_idx:end, :, :), 90, 1); %<--- time index takes <time_skip> into consideration
+roughness90Pc = prctile(roughnessTDep(time_skip_idx:end, :), 90, 1); %<--- time index takes <time_skip> into consideration
 
 %% Output assignment
 

--- a/psychoacoustic_metrics/Tonality_ECMA418_2/Tonality_ECMA418_2.m
+++ b/psychoacoustic_metrics/Tonality_ECMA418_2/Tonality_ECMA418_2.m
@@ -145,7 +145,7 @@ function OUT = Tonality_ECMA418_2(insig, fs, fieldtype, time_skip, show)
 % Institution: University of Salford / ANV Measurement Systems
 %
 % Date created: 07/08/2023
-% Date last modified: 27/06/2025
+% Date last modified: 23/07/2025
 % MATLAB version: 2023b
 %
 % Copyright statement: This file and code is part of work undertaken within
@@ -267,6 +267,9 @@ B = 0.003;
 cal_T = 2.8758615;  % calibration factor in Section 6.2.8 Equation 51 ECMA-418-2:2025 [c_T]
 cal_Tx = 1/0.9999043734252;  % Adjustment to calibration factor (Footnote 22 ECMA-418-2:2025)
 
+% Footnote 14 standardised epsilon
+epsilon = 1e-12;
+
 %% Signal processing
 
 % Input pre-processing
@@ -344,7 +347,7 @@ for chan = size(pn_om, 2):-1:1
                            2*blockSizeDupe(zBand), 1);
         % Section 6.2.2 Equation 29 ECMA-418-2:2025 [phi_l,z(m)]
         denom = sqrt(cumsum(pn_rlz.^2, 1, 'reverse').*flipud(cumsum(pn_rlz.^2)))...
-                + 1e-12;
+                + epsilon;
 
         % note that the block length is used here, rather than the 2*s_b,
         % for compatability with the remaining code - beyond 0.75*s_b is
@@ -434,7 +437,7 @@ for chan = size(pn_om, 2):-1:1
         % Equation 42 ECMA-418-2:2025 signal-noise-ratio first approximation
         % (ratio of tonal component loudness to non-tonal component loudness in critical band)
         % [SNRhat(l,z)]
-        SNRlz1 = bandTonalLoudness./((bandLoudness - bandTonalLoudness) + 1e-12);
+        SNRlz1 = bandTonalLoudness./((bandLoudness - bandTonalLoudness) + epsilon);
 
         % Equation 43 ECMA-418-2:2025 low pass filtered specific loudness
         % of non-tonal component in critical band [Ntilde'_tonal(l,z)]
@@ -480,7 +483,7 @@ for chan = size(pn_om, 2):-1:1
     % Calculation of specific tonality
     % --------------------------------
     % Section 6.2.8 Equation 49 ECMA-418-2:2025 [SNR(l)]
-    overallSNR = max(specTonalLoudness, [], 2)./(1e-12 + sum(specNoiseLoudness, 2));  % loudness signal-noise-ratio
+    overallSNR = max(specTonalLoudness, [], 2)./(sum(specNoiseLoudness, 2) + epsilon);  % loudness signal-noise-ratio
     
     % Section 6.2.8 Equation 50 ECMA-418-2:2025 [q(l)]
     crit = exp(-A*(overallSNR - B));
@@ -505,9 +508,9 @@ for chan = size(pn_om, 2):-1:1
 
         % Section 6.2.9 Equation 53 ECMA-418-2:2025  
         specTonalityAvg(1, zBand, chan)...
-            = sum(specTonality(mask, zBand, chan), 1)./(nnz(mask) + 1e-12); %<--- time index takes <time_skip> into consideration
+            = sum(specTonality(mask, zBand, chan), 1)./(nnz(mask) + epsilon); %<--- time index takes <time_skip> into consideration
         specTonalityAvgFreqs(1, zBand, chan)...
-            = sum(specTonalityFreqs(mask, zBand, chan), 1)./(nnz(mask) + 1e-12); %<--- time index takes <time_skip> into consideration
+            = sum(specTonalityFreqs(mask, zBand, chan), 1)./(nnz(mask) + epsilon); %<--- time index takes <time_skip> into consideration
     end
 
     % Calculation of overall tonality Section 6.2.10
@@ -530,7 +533,7 @@ for chan = size(pn_om, 2):-1:1
 
     % Section 6.2.11 Equation 63 ECMA-418-2:2025
     % Time-averaged total tonality [T]
-    tonalityAvg(chan) = sum(tonalityTDep(mask, chan))/(nnz(mask) + eps); %<--- time index takes <time_skip> into consideration
+    tonalityAvg(chan) = sum(tonalityTDep(mask, chan))/(nnz(mask) + epsilon); %<--- time index takes <time_skip> into consideration
 
 %% Output plotting
 


### PR DESCRIPTION
1. Moved all epsilons to standardised value 1e-12 (instead of using eps).
2. Added explicit indexing for combined binaural specific calculation, to avoid inadvertent miscalculations when using line-by-line inputs rather than function call.
3. Removed redundant 3rd dimension indexing in 90th percentile roughness calculation.