### PR TITLE
fix: amend bandsharing adjustment procedure

### DIFF
--- a/psychoacoustic_metrics/EPNL_FAR_Part36/EPNL_FAR_Part36.m
+++ b/psychoacoustic_metrics/EPNL_FAR_Part36/EPNL_FAR_Part36.m
@@ -15,8 +15,8 @@ function OUT = EPNL_FAR_Part36( insig, fs, method, dt, threshold, show )
 %        Environmental Protection, Volume I - Aircraft Noise, Eighth Edition,
 %        July 2017, Internation Civil Aviation Organization
 %
-%   [3] International Civil Aviation Organization (2015) Doc 9501, Environmental Technical Manual
-%        Volume I, Procedures for the Noise Certification of Aircraft, Second Edition - ISBN 978-92-9249-721-7
+%   [3] International Civil Aviation Organization (2018) Doc 9501, Environmental Technical Manual
+%        Volume I, Procedures for the Noise Certification of Aircraft, Third Edition - ISBN 978-92-9258-369-9
 %
 %   PLEASE NOTE - Requirements from the FAA regulations are:
 %       1) The third octave frequency analysis is limited from 50 Hz to 10 kHz


### PR DESCRIPTION
feat: get_PNLT bandsharing procedure was omitted if the Cmax(kM) index was near the start or end of the spectral time-series. This amendment averages the Cavg over the available Cmax values within the -2, +2 interval of kM using a logical mask. This seems a more reasonable approach than omitting the adjustment entirely if some indices are negative or outside the length of the series.

Addresses reopened issue #6 .

docs: Also updated docstring references in EPNL_FAR_Part36