### PR TITLE
feat!: vectorised psychoacoustic annoyance

### DIFF
--- a/psychoacoustic_metrics/PsychoacousticAnnoyance_Di2016/PsychoacousticAnnoyance_Di2016.m
+++ b/psychoacoustic_metrics/PsychoacousticAnnoyance_Di2016/PsychoacousticAnnoyance_Di2016.m
@@ -111,6 +111,8 @@ function OUT = PsychoacousticAnnoyance_Di2016(insig,fs,LoudnessField,time_skip,s
 %
 % Author: Gil Felix Greco, Braunschweig 05.04.2023
 % Author: Gil Felix Greco, Braunschweig 16.02.2025 - introduced get_statistics function
+% Modified: Mike Lotinga, 29.05.2026 - fixed bug caused by axes swap in
+% sharpness following vectorisation
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 if nargin == 0
     help PsychoacousticAnnoyance_Di2016
@@ -266,7 +268,7 @@ else % for signals longer than 2 seconds
     idx_S=idx_L;    % indice is the same as the loudness
     
     S.time=S.time(1:idx_S);  % step 2)
-    S.InstantaneousSharpness=S.InstantaneousSharpness(1,1:idx_S);  % step 2)
+    S.InstantaneousSharpness=S.InstantaneousSharpness(1:idx_S,1);  % step 2)
     
     % roughness
     [~,idx_R] = min( abs(R.time-LastTime) ); % step 1) find idx

--- a/psychoacoustic_metrics/PsychoacousticAnnoyance_Di2016/PsychoacousticAnnoyance_Di2016.m
+++ b/psychoacoustic_metrics/PsychoacousticAnnoyance_Di2016/PsychoacousticAnnoyance_Di2016.m
@@ -297,40 +297,28 @@ else % for signals longer than 2 seconds
     %% Time-varying psychoacoustic annoyance
     
     % declaring variables for pre allocating memory
-    PA=zeros(1,length(L.time));
-    ws=zeros(1,length(L.time));
-    wfr=zeros(1,length(L.time));
-    wt=zeros(1,length(L.time));
+    ws = zeros(length(L.time), 1);
     
-    for i=1:length(L.time)
-        
-        % sharpness influence
-        if S.InstantaneousSharpness(i) > 1.75
-            ws(i) = (S.InstantaneousSharpness(i)-1.75).*(log10(L.InstantaneousLoudness(i)+10))./4; % in the Fastl&zwicker book, ln is used but it is not clear if it is natural log or log10, but most of subsequent literature uses log10
-        else
-            ws(i) = 0;
-        end
-        
-        ws( isinf(ws) | isnan(ws) ) = 0;  % replace inf and NaN with zeros
-        
-        % influence of roughness and fluctuation strength
-        wfr(i) = ( 2.18./(L.InstantaneousLoudness(i).^(0.4)) ).*(0.4.*fluctuation(i)+0.6.*roughness(i));
-        
-        wfr( isinf(wfr) | isnan(wfr) ) = 0;  % replace inf and NaN with zeros
-        
-        % Tonality influence
-        wt(i) = (beta./(L.InstantaneousLoudness(i).^(alpha))) .* tonality(i);
-        
-        wt( isinf(wt) | isnan(wt) ) = 0;  % replace inf and NaN with zeros
-        
-        % Di's modified psychoacoustic annoyance
-        PA(i) = L.InstantaneousLoudness(i).*( 1 + sqrt( ws(i).^2 + wfr(i).^2 + wt(i).^2 ) );
-        
-    end
+    % sharpness influence
+    % in Widmann (1992), log is used without specifying the base. In
+    % Fastl&Zwicker (2007), lg is used and subsequent literature also uses log10
+    ws(S.InstantaneousSharpness > 1.75) = (S.InstantaneousSharpness(S.InstantaneousSharpness > 1.75) - 1.75).*(log10(L.InstantaneousLoudness(S.InstantaneousSharpness > 1.75) + 10))/4;
+    ws(isinf(ws) | isnan(ws)) = 0;  % replace inf and NaN with zeros
     
-    OUT.wt=sqrt(wt); % OUTPUT: tonality and loudness weighting function (not squared)
-    OUT.wfr=wfr;     % OUTPUT: fluctuation strength and sharpness weighting function (not squared)
-    OUT.ws=ws;       % OUTPUT: sharpness and loudness weighting function (not squared)
+    % influence of roughness and fluctuation strength
+    wfr = (2.18./(L.InstantaneousLoudness.^(0.4))).*(0.4.*fluctuation + 0.6.*roughness);
+    wfr(isinf(wfr) | isnan(wfr)) = 0;  % replace inf and NaN with zeros
+    
+    % Tonality influence
+    wt = (beta./(L.InstantaneousLoudness.^(alpha))) .* tonality;
+    wt(isinf(wt) | isnan(wt)) = 0;  % replace inf and NaN with zeros
+    
+    % Di's modified psychoacoustic annoyance
+    PA = L.InstantaneousLoudness.*(1 + sqrt( ws.^2 + wfr.^2 + wt.^2));
+    
+    OUT.wt = sqrt(wt); % OUTPUT: tonality and loudness weighting function (not squared)
+    OUT.wfr = wfr;     % OUTPUT: fluctuation strength and sharpness weighting function (not squared)
+    OUT.ws = ws;       % OUTPUT: sharpness and loudness weighting function (not squared)
     
     %% (scalar) psychoacoustic annoyance - computed directly from percentile values
     

--- a/psychoacoustic_metrics/PsychoacousticAnnoyance_More2010/PsychoacousticAnnoyance_More2010.m
+++ b/psychoacoustic_metrics/PsychoacousticAnnoyance_More2010/PsychoacousticAnnoyance_More2010.m
@@ -102,6 +102,8 @@ function OUT = PsychoacousticAnnoyance_More2010(insig,fs,LoudnessField,time_skip
 %
 % Author: Gil Felix Greco, Braunschweig 05.04.2023
 % Author: Gil Felix Greco, Braunschweig 16.02.2025 - introduced get_statistics function
+% Modified: Mike Lotinga, 29.05.2026 - fixed bug caused by axes swap in
+% sharpness following vectorisation
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 if nargin == 0
     help PsychoacousticAnnoyance_More2010;
@@ -247,7 +249,7 @@ else % for signals larger than 2 seconds
     idx_S=idx_L;    % indice is the same as the loudness
     
     S.time=S.time(1:idx_S);  % step 2)
-    S.InstantaneousSharpness=S.InstantaneousSharpness(1,1:idx_S);  % step 2)
+    S.InstantaneousSharpness=S.InstantaneousSharpness(1:idx_S,1);  % step 2)
     
     % roughness
     [~,idx_R] = min( abs(R.time-LastTime) ); % step 1) find idx

--- a/psychoacoustic_metrics/PsychoacousticAnnoyance_More2010/PsychoacousticAnnoyance_More2010.m
+++ b/psychoacoustic_metrics/PsychoacousticAnnoyance_More2010/PsychoacousticAnnoyance_More2010.m
@@ -278,40 +278,28 @@ else % for signals larger than 2 seconds
     %% Time-varying psychoacoustic annoyance
     
     % declaring variables for pre allocating memory
-    PA=zeros(1,length(L.time));
-    ws=zeros(1,length(L.time));
-    wfr=zeros(1,length(L.time));
-    wt=zeros(1,length(L.time));
+    ws = zeros(length(L.time), 1);
+        
+    % sharpness influence
+    % in Widmann (1992), log is used without specifying the base. In
+    % Fastl&Zwicker (2007), lg is used and subsequent literature also uses log10
+    ws(S.InstantaneousSharpness > 1.75) = (S.InstantaneousSharpness(S.InstantaneousSharpness > 1.75) - 1.75).*(log10(L.InstantaneousLoudness(S.InstantaneousSharpness > 1.75) + 10))/4;
+    ws(isinf(ws) | isnan(ws)) = 0;  % replace inf and NaN with zeros
     
-    for i=1:length(L.time)
-        
-        % sharpness influence
-        if S.InstantaneousSharpness(i) > 1.75
-            ws(i) = (S.InstantaneousSharpness(i)-1.75).*(log10(L.InstantaneousLoudness(i)+10))./4; % in the Fastl&zwicker book, ln is used but it is not clear if it is natural log or log10, but most of subsequent literature uses log10
-        else
-            ws(i) = 0;
-        end
-        
-        ws( isinf(ws) | isnan(ws) ) = 0;  % replace inf and NaN with zeros
-        
-        % influence of roughness and fluctuation strength
-        wfr(i) = ( 2.18./(L.InstantaneousLoudness(i).^(0.4)) ).*(0.4.*fluctuation(i)+0.6.*roughness(i));
-        
-        wfr( isinf(wfr) | isnan(wfr) ) = 0;  % replace inf and NaN with zeros
-        
-        % Tonality influence
-        wt(i) = abs( ( 1-exp(-gamma_4.*L.InstantaneousLoudness(i)) ).^2 .*( 1-exp(-gamma_5.*tonality(i)) ).^2 );
-        
-        wt( isinf(wt) | isnan(wt) ) = 0;  % replace inf and NaN with zeros
-        
-        % More's modified psychoacoustic annoyance
-        PA(i) = abs(L.InstantaneousLoudness(i).*( 1 + sqrt( gamma_0 + (gamma_1.*ws(i).^2) + (gamma_2.*wfr(i).^2) + (gamma_3.*wt(i)) ) ));
-        
-    end
+    % influence of roughness and fluctuation strength
+    wfr = (2.18./(L.InstantaneousLoudness.^(0.4)) ).*(0.4*fluctuation + 0.6.*roughness);
+    wfr( isinf(wfr) | isnan(wfr) ) = 0;  % replace inf and NaN with zeros
     
-    OUT.wt=sqrt(wt); % OUTPUT: tonality and loudness weighting function (not squared)
-    OUT.wfr=wfr;     % OUTPUT: fluctuation strength and sharpness weighting function (not squared)
-    OUT.ws=ws;       % OUTPUT: sharpness and loudness weighting function (not squared)
+    % Tonality influence
+    wt = abs( ( 1-exp(-gamma_4.*L.InstantaneousLoudness) ).^2 .*( 1-exp(-gamma_5.*tonality) ).^2 );
+    wt( isinf(wt) | isnan(wt) ) = 0;  % replace inf and NaN with zeros
+    
+    % More's modified psychoacoustic annoyance
+    PA = abs(L.InstantaneousLoudness.*(1 + sqrt(gamma_0 + (gamma_1.*ws.^2) + (gamma_2.*wfr.^2) + (gamma_3.*wt)))); 
+    
+    OUT.wt = sqrt(wt); % OUTPUT: tonality and loudness weighting function (not squared)
+    OUT.wfr = wfr;     % OUTPUT: fluctuation strength and sharpness weighting function (not squared)
+    OUT.ws = ws;       % OUTPUT: sharpness and loudness weighting function (not squared)
     
     %% (scalar) psychoacoustic annoyance - computed directly from percentile values
     

--- a/psychoacoustic_metrics/PsychoacousticAnnoyance_Widmann1992/PsychoacousticAnnoyance_Widmann1992.m
+++ b/psychoacoustic_metrics/PsychoacousticAnnoyance_Widmann1992/PsychoacousticAnnoyance_Widmann1992.m
@@ -258,35 +258,23 @@ else % for signals larger than 2 seconds
     %% Time-varying psychoacoustic annoyance
     
     % declaring variables for pre allocating memory
-    PA=zeros(1,length(L.time));
-    ws=zeros(1,length(L.time));
-    wfr=zeros(1,length(L.time));
+    ws = zeros(length(L.time), 1);
     
-    for i=1:length(L.time)
+    % sharpness influence
+    % in Widmann (1992), log is used without specifying the base. In
+    % Fastl&Zwicker (2007), lg is used and subsequent literature also uses log10
+    ws(S.InstantaneousSharpness > 1.75) = (S.InstantaneousSharpness(S.InstantaneousSharpness > 1.75) - 1.75).*(log10(L.InstantaneousLoudness(S.InstantaneousSharpness > 1.75) + 10))/4;
+    ws(isinf(ws) | isnan(ws)) = 0;  % replace inf and NaN with zeros
         
-        % sharpness influence
-        if S.InstantaneousSharpness(i) > 1.75
-            % in Widmann (1992), log is used without specifying the base. In
-            % Fastl&Zwicker (2007), lg is used and subsequent literature also uses log10
-            ws(i) = (S.InstantaneousSharpness(i)-1.75).*(log10(L.InstantaneousLoudness(i)+10))./4;
-        else
-            ws(i) = 0;
-        end
+    % influence of roughness and fluctuation strength
+    wfr = ( 2.18./(L.InstantaneousLoudness.^(0.4)) ).*(0.4*fluctuation + 0.6.*roughness);
+    wfr(isinf(wfr) | isnan(wfr)) = 0;  % replace inf and NaN with zeros
         
-        ws(isinf(ws)|isnan(ws)) = 0;  % replace inf and NaN with zeros
-        
-        % influence of roughness and fluctuation strength
-        wfr(i) = ( 2.18./(L.InstantaneousLoudness(i).^(0.4)) ).*(0.4.*fluctuation(i)+0.6.*roughness(i));
-        
-        wfr(isinf(wfr)|isnan(wfr)) = 0;  % replace inf and NaN with zeros
-        
-        % psychoacoustic annoyance
-        PA(i) = L.InstantaneousLoudness(i).*(1 + sqrt (ws(i).^2 + wfr(i).^2));
-        
-    end
+    % psychoacoustic annoyance
+    PA = L.InstantaneousLoudness.*(1 + sqrt (ws.^2 + wfr.^2));
     
-    OUT.wfr=wfr;     % OUTPUT: fluctuation strength and sharpness weighting function (not squared)
-    OUT.ws=ws;       % OUTPUT: sharpness and loudness weighting function (not squared)
+    OUT.wfr = wfr;     % OUTPUT: fluctuation strength and sharpness weighting function (not squared)
+    OUT.ws = ws;       % OUTPUT: sharpness and loudness weighting function (not squared)
     
     %% (scalar) psychoacoustic annoyance - computed directly from percentile values
     

--- a/psychoacoustic_metrics/PsychoacousticAnnoyance_Widmann1992/PsychoacousticAnnoyance_Widmann1992.m
+++ b/psychoacoustic_metrics/PsychoacousticAnnoyance_Widmann1992/PsychoacousticAnnoyance_Widmann1992.m
@@ -112,6 +112,8 @@ function OUT = PsychoacousticAnnoyance_Widmann1992(insig,fs,LoudnessField,time_s
 % Author: Gil Felix Greco, Braunschweig 16.02.2025 - introduced get_statistics function
 % Modified: Mike Lotinga, 12.06.2025 - created from
 % PsychoacousticAnnoyance_Zwicker1999.m
+% Modified: Mike Lotinga, 29.05.2026 - fixed bug caused by axes swap in
+% sharpness following vectorisation
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 if nargin == 0
     help PsychoacousticAnnoyance_Widmann1992;
@@ -235,7 +237,7 @@ else % for signals larger than 2 seconds
     idx_S=idx_L;    % indice is the same as the loudness
     
     S.time=S.time(1:idx_S);  % step 2)
-    S.InstantaneousSharpness=S.InstantaneousSharpness(1,1:idx_S);  % step 2)
+    S.InstantaneousSharpness=S.InstantaneousSharpness(1:idx_S,1);  % step 2)
     
     % roughness
     [~,idx_R] = min( abs(R.time-LastTime) ); % step 1) find idx

--- a/psychoacoustic_metrics/Sharpness_DIN45692/Sharpness_DIN45692.m
+++ b/psychoacoustic_metrics/Sharpness_DIN45692/Sharpness_DIN45692.m
@@ -69,6 +69,8 @@ function OUT = Sharpness_DIN45692(insig, fs, weight_type, LoudnessField, Loudnes
 %
 % Author: Gil Felix Greco, Braunschweig 09.03.2023
 % Author: Gil Felix Greco, Braunschweig 16.02.2025 - introduced get_statistics function
+% Modified: Mike Lotinga 29.05/2026 - vectorised for 95% reduction in
+% compute time
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 if nargin == 0
     help Sharpness_DIN45692;
@@ -89,7 +91,7 @@ if nargin < 7
     end
 end
 
-if LoudnessMethod==1 % stationary loudness calculation
+if LoudnessMethod == 1 % stationary loudness calculation
     
     L = Loudness_ISO532_1(insig, fs,... % input signal and sampling freq.
                       LoudnessField,... % free field = 0; diffuse field = 1;
@@ -98,14 +100,11 @@ if LoudnessMethod==1 % stationary loudness calculation
                       show_loudness);   % show loudness results
     
     n = size(L.SpecificLoudness,2);
-    loudness_sones=zeros(size(L.SpecificLoudness,1),1); % pre allocate memory
     SpecificLoudness=L.SpecificLoudness;
     
-    for i=1:size(L.SpecificLoudness,1)
-        loudness_sones(i)=sum(L.SpecificLoudness(i,:),2).*0.10;
-    end
+    loudness_sones = sum(L.SpecificLoudness, 2).*0.10;
     
-elseif LoudnessMethod==2 % time-varying loudness calculation
+elseif LoudnessMethod == 2 % time-varying loudness calculation
     
     L = Loudness_ISO532_1(insig, fs,... % input signal and sampling freq.
                       LoudnessField,... % free field = 0; diffuse field = 1;
@@ -114,50 +113,42 @@ elseif LoudnessMethod==2 % time-varying loudness calculation
                       show_loudness);   % show loudness results
     
     n = size(L.InstantaneousSpecificLoudness,2);
-    loudness_sones=zeros(size(L.InstantaneousSpecificLoudness,1),1); % pre allocate memory
     SpecificLoudness=L.InstantaneousSpecificLoudness;
     
-    for i=1:size(L.InstantaneousSpecificLoudness,1)
-        loudness_sones(i)=sum(L.InstantaneousSpecificLoudness(i,:),2).*0.10;
-    end
+    loudness_sones = sum(L.InstantaneousSpecificLoudness, 2).*0.10;
     
 end
 
-z=linspace(0.1,24,n); % create bark axis
+z = linspace(0.1, 24, n); % create bark axis
 
-%% Sharpness calculation %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% Sharpness calculation
 
 switch weight_type
-    case 'DIN45692'   % Widmann model
+    case 'DIN45692' % Widmann model
         
-        g=il_sharpWeights(z,'standard',[]); % calculate sharpness weighting factors
-        k=0.11; % adjusted to yield 1 acum using SQAT - DIN45692 allows 0.105<=k<=0.0115 for this weighting function
-        
-        for i=1:size(SpecificLoudness,1)
-            s(i) = k * sum(SpecificLoudness(i,:).*g.*z.*0.10,2) ./ loudness_sones(i);
-        end
-        
+        g = il_sharpWeights(z, 'standard', []); % calculate sharpness weighting factors
+        k = 0.11; % adjusted to yield 1 acum using SQAT - DIN45692 allows 0.105<=k<=0.0115 for this weighting function
+        s = k * sum(SpecificLoudness.*g.*z.*0.10, 2) ./ loudness_sones;
         %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+        
     case 'aures' % Aures model
         
-        for i=1:size(SpecificLoudness,1)
-            g(i,:)=il_sharpWeights(z,'aures',loudness_sones(i)); % calculate sharpness weighting factor
-            s(i) = 0.11 * sum(SpecificLoudness(i,:).*g(i,:).*z.*0.10,2) ./ loudness_sones(i);
-        end
+        g = il_sharpWeights(z, 'aures', loudness_sones); % calculate sharpness weighting factor
+        s = 0.11 * sum(SpecificLoudness.*g.*z.*0.10, 2) ./ loudness_sones;
         
         %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
     case 'bismarck' % von Bismarck
-        g=il_sharpWeights(z,'bismarck',[]); % calculate sharpness weighting factor
+        g = il_sharpWeights(z,'bismarck',[]); % calculate sharpness weighting factor
+        s = 0.11 * sum(SpecificLoudness.*g.*z.*0.10, 2) ./ loudness_sones;
         
-        for i=1:size(SpecificLoudness,1)
-            s(i) = 0.11 * sum(SpecificLoudness(i,:).*g.*z.*0.10,2) ./ loudness_sones(i);
-        end
+        %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 end
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % Output struct for time-varying signals
 
-if LoudnessMethod==2 % (time-varying sharpness)
+if LoudnessMethod == 2 % (time-varying sharpness)
     
     OUT.InstantaneousSharpness = s; % instantaneous sharpness
     OUT.time = L.time;              % time vector
@@ -218,26 +209,22 @@ end % End of Sharpness_DIN45692
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % Embedded function (compute weighting functions according to required model type)
 
-function g = il_sharpWeights(z,type,N)
+function g = il_sharpWeights(z, type, N)
+    switch type
+        case 'standard' % Widmann model according to DIN 45692 (2009)
+            g = zeros(1,length(z));
+            g(z < 15.8) = 1;
+            g(z >= 15.8) = 0.15.*exp(0.42.*((z(z >= 15.8)) - 15.8)) + 0.85;
 
-g=zeros(1,length(z));
+        case 'bismarck' % von bismark's model according to DIN 45692 (2009)
+            g = zeros(1,length(z));
+            g(z < 15) = 1;
+            g(z >= 15) = 0.2.*exp(0.308.*(z(z >= 15) - 15)) + 0.8;
 
-switch type
-    case 'standard' % Widmann model according to DIN 45692 (2009)
-        g(z<15.8)=1;
-        g(z>=15.8)=0.15.*exp( 0.42.*((z(z>=15.8))-15.8) ) + 0.85;
-
-    case 'bismarck' % von bismark's model according to DIN 45692 (2009)
-        g(z<15)=1;
-        g(z>=15)=0.2.*exp( 0.308.*(z(z>=15)-15) ) + 0.8;
-
-    case 'aures'    % Aure's model according to DIN 45692 (2009)
-        for nt=1:length(N)
-            g(nt,:)=0.078.*( exp(0.171.*z)./z ).*( N(nt)./log(0.05.*N(nt)+1));
-        end
-
-end
-
+        case 'aures'    % Aures' model according to DIN 45692 (2009)
+            g = zeros(length(N), length(z));
+            g = 0.078.*(exp(0.171.*z)./z ).*(N./log(0.05.*N + 1));
+    end
 end % end of il_sharpWeights
 
 %**************************************************************************

--- a/psychoacoustic_metrics/Sharpness_DIN45692/Sharpness_DIN45692_from_loudness.m
+++ b/psychoacoustic_metrics/Sharpness_DIN45692/Sharpness_DIN45692_from_loudness.m
@@ -53,6 +53,8 @@ function OUT = Sharpness_DIN45692_from_loudness(SpecificLoudness, weight_type, t
 %
 % Author: Gil Felix Greco, Braunschweig 09.03.2023
 % Author: Gil Felix Greco, Braunschweig 16.02.2025 - introduced get_statistics function
+% Modified: Mike Lotinga 29.05/2026 - vectorised for 95% reduction in
+% compute time
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 if nargin < 5
     if nargout == 0
@@ -62,20 +64,16 @@ if nargin < 5
     end
 end
 
-n = size(SpecificLoudness,2);
-z=linspace(0.1,24,n);   % create bark axis
+n = size(SpecificLoudness, 2);
+z = linspace(0.1, 24, n);   % create bark axis
 
-if size(SpecificLoudness,1)==1 % define method based on the size of the input specific loudness
+if size(SpecificLoudness, 1) == 1 % define method based on the size of the input specific loudness
     method = 0; % (stationary) - Specific loudness [1,sone/Bark]
 else
     method = 1; % (time-varying) - Instantaneous specific loudness [nTimeSteps,sone/Bark]
 end
 
-loudness_sones=zeros(size(SpecificLoudness,1),1); % pre allocate memory
-
-for i=1:size(SpecificLoudness,1)
-    loudness_sones(i)=sum(SpecificLoudness(i,:),2).*0.10;
-end
+loudness_sones = sum(SpecificLoudness, 2).*0.10;
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % Sharpness calculation
@@ -83,28 +81,20 @@ end
 switch weight_type
     case 'DIN45692' % Widmann model
         
-        g=il_sharpWeights(z,'standard',[]); % calculate sharpness weighting factors
-        k=0.11; % adjusted to yield 1 acum using SQAT - DIN45692 allows 0.105<=k<=0.0115 for this weighting function
-        
-        for i=1:size(SpecificLoudness,1)
-            s(i) = k * sum(SpecificLoudness(i,:).*g.*z.*0.10,2) ./ loudness_sones(i);
-        end
+        g = il_sharpWeights(z, 'standard', []); % calculate sharpness weighting factors
+        k = 0.11; % adjusted to yield 1 acum using SQAT - DIN45692 allows 0.105<=k<=0.0115 for this weighting function
+        s = k * sum(SpecificLoudness.*g.*z.*0.10, 2) ./ loudness_sones;
         %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
         
     case 'aures' % Aures model
         
-        for i=1:size(SpecificLoudness,1)
-            g(i,:)=il_sharpWeights(z,'aures',loudness_sones(i)); % calculate sharpness weighting factor
-            s(i) = 0.11 * sum(SpecificLoudness(i,:).*g(i,:).*z.*0.10,2) ./ loudness_sones(i);
-        end
+        g = il_sharpWeights(z, 'aures', loudness_sones); % calculate sharpness weighting factor
+        s = 0.11 * sum(SpecificLoudness.*g.*z.*0.10, 2) ./ loudness_sones;
         
         %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
     case 'bismarck' % von Bismarck
-        g=il_sharpWeights(z,'bismarck',[]); % calculate sharpness weighting factor
-        
-        for i=1:size(SpecificLoudness,1)
-            s(i) = 0.11 * sum(SpecificLoudness(i,:).*g.*z.*0.10,2) ./ loudness_sones(i);
-        end
+        g = il_sharpWeights(z,'bismarck',[]); % calculate sharpness weighting factor
+        s = 0.11 * sum(SpecificLoudness.*g.*z.*0.10, 2) ./ loudness_sones;
         
         %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 end
@@ -112,7 +102,7 @@ end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %   output struct for time-varying signals
 
-if method==1 % (time-varying sharpness)
+if method == 1 % (time-varying sharpness)
     
     OUT.InstantaneousSharpness = s; % instantaneous sharpness
     OUT.time = time;                % time vector
@@ -159,7 +149,7 @@ if method==1 % (time-varying sharpness)
         
     end
     
-elseif method==0 % (stationary sharpness)
+elseif method == 0 % (stationary sharpness)
     
     OUT.Sharpness = s;                       % sharpness
     
@@ -170,26 +160,23 @@ end % end of function
 % Embedded function (compute weighting functions according to required model type)
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-function g = il_sharpWeights(z,type,N)
-
-    g=zeros(1,length(z));
-
+function g = il_sharpWeights(z, type, N)
     switch type
         case 'standard' % Widmann model according to DIN 45692 (2009)
-            g(z<15.8)=1;
-            g(z>=15.8)=0.15.*exp( 0.42.*((z(z>=15.8))-15.8) ) + 0.85;
+            g = zeros(1,length(z));
+            g(z < 15.8) = 1;
+            g(z >= 15.8) = 0.15.*exp(0.42.*((z(z >= 15.8)) - 15.8)) + 0.85;
 
         case 'bismarck' % von bismark's model according to DIN 45692 (2009)
-            g(z<15)=1;
-            g(z>=15)=0.2.*exp( 0.308.*(z(z>=15)-15) ) + 0.8;
+            g = zeros(1,length(z));
+            g(z < 15) = 1;
+            g(z >= 15) = 0.2.*exp(0.308.*(z(z >= 15) - 15)) + 0.8;
 
         case 'aures'    % Aures' model according to DIN 45692 (2009)
-            for nt=1:length(N)
-                g(nt,:)=0.078.*( exp(0.171.*z)./z ).*( N(nt)./log(0.05.*N(nt)+1));
-            end
-
+            g = zeros(length(N), length(z));
+            g = 0.078.*(exp(0.171.*z)./z ).*(N./log(0.05.*N + 1));
     end
-end
+end % end of il_sharpWeights
 
 %**************************************************************************
 %

--- a/validation/Sharpness_DIN45692/validation_Sharpness_DIN45692_narrowband_and_broadband_signals.m
+++ b/validation/Sharpness_DIN45692/validation_Sharpness_DIN45692_narrowband_and_broadband_signals.m
@@ -21,7 +21,7 @@
 %
 % Author: Gil Felix Greco, Braunschweig 01.03.2023 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-clear all; close all; clc;
+% clear all; close all; clc;
 
 save_figs = 0; % save figure flag
 


### PR DESCRIPTION
Vectorised calculation of time-dependent PA for speed improvement.

The output is re-oriented with time along axis 1 (which matches the other metrics), so downstream analyses codes may need to be updated to switch the dimensions.