### PR TITLE
Bug in the DeltaB variable within get_PNLT.m

### DIFF
--- a/psychoacoustic_metrics/EPNL_FAR_Part36/helper/get_PNLT.m
+++ b/psychoacoustic_metrics/EPNL_FAR_Part36/helper/get_PNLT.m
@@ -10,8 +10,8 @@ function [PNLT, PNLTM, PNLTM_idx, OUT] = get_PNLT( input, freq_bands, PNL )
 %          corresponding PNL(k) values in order to determine the Tone-corrected
 %          perceived noise levels, PNLT(k) 
 %
-%       3) Bandsharing adjustment to PNLTM added in 20.06.2024, amended
-%          17.12.2025
+%       3) Bandsharing adjustment to PNLTM added in 20.06.2024 (amended
+%          17.12.2025, amended again 31/08/2026)
 %
 % A detailed definition and discussion about the tone-correction factor is
 % provided in:
@@ -224,7 +224,7 @@ if size(Cmax,1)~=1
     Cavg = mean(Cmax(validIndices));
 
     if Cavg > Cmax(PNLTM_idx)
-        DeltaB = Cavg-Cmax(PNLTM_idx);
+        DeltaB = Cavg - Cmax(PNLTM_idx);  % follows definition corrected in amended edition 14 (2024) of ICAO Annex 16 Vol 1 Appendix 2
     else
         DeltaB = 0;
     end

--- a/psychoacoustic_metrics/EPNL_FAR_Part36/helper/get_PNLT.m
+++ b/psychoacoustic_metrics/EPNL_FAR_Part36/helper/get_PNLT.m
@@ -224,7 +224,7 @@ if size(Cmax,1)~=1
     Cavg = mean(Cmax(validIndices));
 
     if Cavg > Cmax(PNLTM_idx)
-        DeltaB = Cavg*Cmax(PNLTM_idx);
+        DeltaB = Cavg-Cmax(PNLTM_idx);
     else
         DeltaB = 0;
     end


### PR DESCRIPTION
I believe that Line 227 should read
 DeltaB = Cavg-Cmax(PNLTM_idx);
instead of the current
 DeltaB = Cavg*Cmax(PNLTM_idx);

See https://www.easa.europa.eu/en/downloads/139024/en or https://www.ecfr.gov/current/title-14/part-36/appendix-Appendix%20A%20to%20Part%2036