### PR TITLE
fix: crash of FluctuationStrength_Osses2016 on very loud signals

### DIFF
--- a/psychoacoustic_metrics/FluctuationStrength_Osses2016/FluctuationStrength_Osses2016.m
+++ b/psychoacoustic_metrics/FluctuationStrength_Osses2016/FluctuationStrength_Osses2016.m
@@ -90,6 +90,9 @@ function OUT = FluctuationStrength_Osses2016(insig,fs,method,time_skip,show,stru
 % Author: Gil Felix Greco, Braunschweig 16.02.2025 - introduced get_statistics function
 % Modified: Mike Lotinga May 2025 - incorporated efficiency improvements in
 % TerhardtExcitationPatterns.m to speed up calculation.
+% Modified: Sergio Aguirre, September 2026 - a single warning per call when
+% the Terhardt upper slope is clamped to zero in any frame (component level
+% above 120 + 1150/f dB, see TerhardtExcitationPatterns.m)
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 if nargin == 0
     help FluctuationStrength_Osses2016;
@@ -155,6 +158,7 @@ insig = buffer(insig,N,overlap,'nodelay');
 t_b     = buffer(t_b,N,overlap,'nodelay');
 nFrames = size(insig,2);
 fluct   = zeros(1,nFrames); % Memory allocation
+clampFrames = 0; clampLdB = -Inf; clampFreq = NaN; % frames with a clamped Terhardt slope
 
 %% ei = peripheral_stage(insig,fs,N);
 % 1. Cosine window:
@@ -185,7 +189,14 @@ for iFrame = nFrames:-1:1
     dBFS = 94; % corresponds to 1 Pa (new default in SQAT)
     % dBFS = 100; % unit amplitude corresponds to 100 dB (AMT Toolbox 
                   % convention, default by the original authors)
-    ei   = TerhardtExcitationPatterns(signal,fs,dBFS);
+    [ei, ~, ~, clamp] = TerhardtExcitationPatterns(signal,fs,dBFS); % <clamp> requested, so the filterbank does not warn per frame
+    if clamp.n > 0
+        clampFrames = clampFrames + 1;
+        if clamp.LdB > clampLdB
+            clampLdB  = clamp.LdB;
+            clampFreq = clamp.freq;
+        end
+    end
     dz   = 0.5; % Barks, frequency step
     z    = 0.5:dz:23.5; % Bark
     % fc   = bark2hz(z);  % unused variable
@@ -211,6 +222,17 @@ for iFrame = nFrames:-1:1
     fi(iFrame,:)  = model_par.cal * fi_;
     fluct(iFrame) = dz*sum(fi(iFrame,:)); % total fluct = integration of the specific fluct. strength pattern
     
+end
+
+% One warning per call, aggregated over the frames (the filterbank itself
+% stays silent because <clamp> is requested above)
+if clampFrames > 0
+    warning('SQAT:FluctuationStrength:TerhardtSlopeClamped', ...
+        ['Terhardt upper slope clamped to zero in %d of %d frame(s): at least one ' ...
+         'component exceeds 120 + 1150/f dB (highest: %.1f dB at %.0f Hz). The ' ...
+         'fluctuation strength of those frames is an extrapolation outside the range ' ...
+         'over which the metric was validated; check the dBFS calibration.'], ...
+        clampFrames, nFrames, clampLdB, clampFreq);
 end
 
 

--- a/psychoacoustic_metrics/FluctuationStrength_Osses2016/private/TerhardtExcitationPatterns.m
+++ b/psychoacoustic_metrics/FluctuationStrength_Osses2016/private/TerhardtExcitationPatterns.m
@@ -4,6 +4,9 @@ function [ei,ei_f,freq] = TerhardtExcitationPatterns(insig,fs,dBFS)
 % Author: Alejandro Osses, extracted from FluctuationStrength_Osses2016.m on 12/05/2023
 % Modified: Mike Lotinga, May 2025 (parallelised code to omit loop over
 % whichL for improved performance)
+% Modified: Sergio Aguirre, September 2026 (masked both sides of the S2
+% assignment, which crashed above a component level of about 121 dB, and
+% warn when the upper slope is clamped to zero)
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 if nargin < 3
@@ -47,6 +50,26 @@ S1 = -27;
 S2 = zeros(nL, 1);
 
 steep = -24 - (230./freqs(whichL)) + (0.2*LdB(whichL));
+% Terhardt's upper slope is defined for steep < 0 only. A component whose
+% level exceeds 120 + 1150/f dB (about 121 dB at 1 kHz) gives steep >= 0,
+% which would mean an excitation that does not decay towards higher
+% frequencies. S2 stays at zero for such a component (flat spread), so the
+% result is an extrapolation outside the range over which the metric was
+% validated (60 to 70 dB SPL); a wrong dBFS is the most likely cause.
+if any(steep >= 0)
+    [~, iw] = max(steep);
+    warning('SQAT:FluctuationStrength:TerhardtSlopeClamped', ...
+        ['Terhardt upper slope clamped to zero for %d component(s) whose level ' ...
+         'exceeds 120 + 1150/f dB (highest: %.1f dB at %.0f Hz). The fluctuation ' ...
+         'strength of this frame is an extrapolation outside the range over which ' ...
+         'the metric was validated; check the dBFS calibration.'], ...
+        nnz(steep >= 0), LdB(whichL(iw)), freqs(whichL(iw)));
+end
+% Both sides are masked on purpose: this reproduces the element-wise guard
+% of the scalar loop in TerhardtExcitationPatterns_v3.m (S2 stays 0 whenever
+% steep >= 0) and keeps the two sides the same size once any component has
+% steep >= 0. With the right-hand side unmasked the assignment raised a size
+% mismatch error as soon as one component crossed that level.
 S2(steep < 0) = steep(steep < 0);
 S2 = repmat(S2, 1, params.Chno);
 

--- a/psychoacoustic_metrics/FluctuationStrength_Osses2016/private/TerhardtExcitationPatterns.m
+++ b/psychoacoustic_metrics/FluctuationStrength_Osses2016/private/TerhardtExcitationPatterns.m
@@ -47,7 +47,7 @@ S1 = -27;
 S2 = zeros(nL, 1);
 
 steep = -24 - (230./freqs(whichL)) + (0.2*LdB(whichL));
-S2(steep < 0) = steep;
+S2(steep < 0) = steep(steep < 0);
 S2 = repmat(S2, 1, params.Chno);
 
 whichZ = zeros(nL, 2);

--- a/psychoacoustic_metrics/FluctuationStrength_Osses2016/private/TerhardtExcitationPatterns.m
+++ b/psychoacoustic_metrics/FluctuationStrength_Osses2016/private/TerhardtExcitationPatterns.m
@@ -1,12 +1,17 @@
-function [ei,ei_f,freq] = TerhardtExcitationPatterns(insig,fs,dBFS)
-% function [ei,ei_f,freq] = TerhardtExcitationPatterns(insig,fs,dBFS)
+function [ei,ei_f,freq,clamp] = TerhardtExcitationPatterns(insig,fs,dBFS)
+% function [ei,ei_f,freq,clamp] = TerhardtExcitationPatterns(insig,fs,dBFS)
+%
+% The optional fourth output <clamp> reports whether the Terhardt upper
+% slope was clamped to zero for any component (see below); when it is
+% requested, no warning is raised here.
 %
 % Author: Alejandro Osses, extracted from FluctuationStrength_Osses2016.m on 12/05/2023
 % Modified: Mike Lotinga, May 2025 (parallelised code to omit loop over
 % whichL for improved performance)
 % Modified: Sergio Aguirre, September 2026 (masked both sides of the S2
 % assignment, which crashed above a component level of about 121 dB, and
-% warn when the upper slope is clamped to zero)
+% report in <clamp> when the upper slope is clamped to zero, warning only
+% when that output is not requested)
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 if nargin < 3
@@ -35,6 +40,7 @@ LdB = 20*log10(Lg); % il_To_dB(Lg);
 % Use only components that are above the hearing threshold
 MinExcdB = params.MinExcdB(:);
 whichL = find(LdB > MinExcdB);
+clamp = struct('n', 0, 'LdB', [], 'freq', []); % Terhardt upper slope clamped to zero: none so far
 
 if isempty(whichL)
     ei = zeros(params.Chno, params.N);  % Return silence
@@ -56,14 +62,24 @@ steep = -24 - (230./freqs(whichL)) + (0.2*LdB(whichL));
 % frequencies. S2 stays at zero for such a component (flat spread), so the
 % result is an extrapolation outside the range over which the metric was
 % validated (60 to 70 dB SPL); a wrong dBFS is the most likely cause.
-if any(steep >= 0)
+% The clamping is reported in <clamp>: number of components, and level and
+% frequency of the component farthest into the clamped regime. The warning
+% is raised here only when the caller does not request <clamp>, so that a
+% caller running the filterbank once per frame (FluctuationStrength_Osses2016.m)
+% can aggregate the frames and warn once per call.
+clamp.n = nnz(steep >= 0);
+if clamp.n > 0
     [~, iw] = max(steep);
-    warning('SQAT:FluctuationStrength:TerhardtSlopeClamped', ...
-        ['Terhardt upper slope clamped to zero for %d component(s) whose level ' ...
-         'exceeds 120 + 1150/f dB (highest: %.1f dB at %.0f Hz). The fluctuation ' ...
-         'strength of this frame is an extrapolation outside the range over which ' ...
-         'the metric was validated; check the dBFS calibration.'], ...
-        nnz(steep >= 0), LdB(whichL(iw)), freqs(whichL(iw)));
+    clamp.LdB  = LdB(whichL(iw));
+    clamp.freq = freqs(whichL(iw));
+    if nargout < 4
+        warning('SQAT:FluctuationStrength:TerhardtSlopeClamped', ...
+            ['Terhardt upper slope clamped to zero for %d component(s) whose level ' ...
+             'exceeds 120 + 1150/f dB (highest: %.1f dB at %.0f Hz). The fluctuation ' ...
+             'strength of this frame is an extrapolation outside the range over which ' ...
+             'the metric was validated; check the dBFS calibration.'], ...
+            clamp.n, clamp.LdB, clamp.freq);
+    end
 end
 % Both sides are masked on purpose: this reproduces the element-wise guard
 % of the scalar loop in TerhardtExcitationPatterns_v3.m (S2 stays 0 whenever

--- a/psychoacoustic_metrics/FluctuationStrength_Osses2016/private/TerhardtExcitationPatterns_v3.m
+++ b/psychoacoustic_metrics/FluctuationStrength_Osses2016/private/TerhardtExcitationPatterns_v3.m
@@ -2,6 +2,8 @@ function [ei,ei_f,freq] = TerhardtExcitationPatterns_v3(insig,fs,dBFS)
 % function [ei,ei_f,freq] = TerhardtExcitationPatterns_v3(insig,fs,dBFS)
 %
 % Author: Alejandro Osses, extracted from FluctuationStrength_Osses2016.m on 12/05/2023
+% Modified: Sergio Aguirre, September 2026 (warn when the upper slope is
+% clamped to zero, as in the vectorised TerhardtExcitationPatterns.m)
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 if nargin < 3
@@ -34,12 +36,31 @@ nL     = length(whichL);
 % Steepness of slopes
 S1 = -27;			
 S2 = zeros(1,nL);
+steep = zeros(1,nL);
 for w = 1:nL
     idx = whichL(w);
-    steep = -24 - ( 230 / freqs(idx)) + (0.2 * LdB(idx) ); 
-    if steep < 0
-        S2(w) = steep;
+    steep(w) = -24 - ( 230 / freqs(idx)) + (0.2 * LdB(idx) ); 
+    % Element-wise guard: S2(w) stays 0 whenever steep(w) >= 0. The
+    % vectorised TerhardtExcitationPatterns.m masks both sides of its
+    % assignment to reproduce exactly this behaviour.
+    if steep(w) < 0
+        S2(w) = steep(w);
     end
+end
+% Terhardt's upper slope is defined for steep < 0 only. A component whose
+% level exceeds 120 + 1150/f dB (about 121 dB at 1 kHz) gives steep >= 0,
+% which would mean an excitation that does not decay towards higher
+% frequencies. S2 stays at zero for such a component (flat spread), so the
+% result is an extrapolation outside the range over which the metric was
+% validated (60 to 70 dB SPL); a wrong dBFS is the most likely cause.
+if any(steep >= 0)
+    [~, iw] = max(steep);
+    warning('SQAT:FluctuationStrength:TerhardtSlopeClamped', ...
+        ['Terhardt upper slope clamped to zero for %d component(s) whose level ' ...
+         'exceeds 120 + 1150/f dB (highest: %.1f dB at %.0f Hz). The fluctuation ' ...
+         'strength of this frame is an extrapolation outside the range over which ' ...
+         'the metric was validated; check the dBFS calibration.'], ...
+        nnz(steep >= 0), LdB(whichL(iw)), freqs(whichL(iw)));
 end
 
 whichZ      = zeros(2,nL);

--- a/psychoacoustic_metrics/FluctuationStrength_Osses2016/private/TerhardtExcitationPatterns_v3.m
+++ b/psychoacoustic_metrics/FluctuationStrength_Osses2016/private/TerhardtExcitationPatterns_v3.m
@@ -1,9 +1,14 @@
-function [ei,ei_f,freq] = TerhardtExcitationPatterns_v3(insig,fs,dBFS)
-% function [ei,ei_f,freq] = TerhardtExcitationPatterns_v3(insig,fs,dBFS)
+function [ei,ei_f,freq,clamp] = TerhardtExcitationPatterns_v3(insig,fs,dBFS)
+% function [ei,ei_f,freq,clamp] = TerhardtExcitationPatterns_v3(insig,fs,dBFS)
+%
+% The optional fourth output <clamp> reports whether the Terhardt upper
+% slope was clamped to zero for any component (see below); when it is
+% requested, no warning is raised here.
 %
 % Author: Alejandro Osses, extracted from FluctuationStrength_Osses2016.m on 12/05/2023
-% Modified: Sergio Aguirre, September 2026 (warn when the upper slope is
-% clamped to zero, as in the vectorised TerhardtExcitationPatterns.m)
+% Modified: Sergio Aguirre, September 2026 (report in <clamp> when the upper
+% slope is clamped to zero and warn only when that output is not requested,
+% as in the vectorised TerhardtExcitationPatterns.m)
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 if nargin < 3
@@ -32,6 +37,7 @@ LdB = 20*log10(Lg); % il_To_dB(Lg);
 % Use only components that are above the hearing threshold
 whichL = find(LdB > params.MinExcdB);
 nL     = length(whichL);
+clamp = struct('n', 0, 'LdB', [], 'freq', []); % Terhardt upper slope clamped to zero: none so far
 
 % Steepness of slopes
 S1 = -27;			
@@ -53,14 +59,24 @@ end
 % frequencies. S2 stays at zero for such a component (flat spread), so the
 % result is an extrapolation outside the range over which the metric was
 % validated (60 to 70 dB SPL); a wrong dBFS is the most likely cause.
-if any(steep >= 0)
+% The clamping is reported in <clamp>: number of components, and level and
+% frequency of the component farthest into the clamped regime. The warning
+% is raised here only when the caller does not request <clamp>, so that a
+% caller running the filterbank once per frame (FluctuationStrength_Osses2016.m)
+% can aggregate the frames and warn once per call.
+clamp.n = nnz(steep >= 0);
+if clamp.n > 0
     [~, iw] = max(steep);
-    warning('SQAT:FluctuationStrength:TerhardtSlopeClamped', ...
-        ['Terhardt upper slope clamped to zero for %d component(s) whose level ' ...
-         'exceeds 120 + 1150/f dB (highest: %.1f dB at %.0f Hz). The fluctuation ' ...
-         'strength of this frame is an extrapolation outside the range over which ' ...
-         'the metric was validated; check the dBFS calibration.'], ...
-        nnz(steep >= 0), LdB(whichL(iw)), freqs(whichL(iw)));
+    clamp.LdB  = LdB(whichL(iw));
+    clamp.freq = freqs(whichL(iw));
+    if nargout < 4
+        warning('SQAT:FluctuationStrength:TerhardtSlopeClamped', ...
+            ['Terhardt upper slope clamped to zero for %d component(s) whose level ' ...
+             'exceeds 120 + 1150/f dB (highest: %.1f dB at %.0f Hz). The fluctuation ' ...
+             'strength of this frame is an extrapolation outside the range over which ' ...
+             'the metric was validated; check the dBFS calibration.'], ...
+            clamp.n, clamp.LdB, clamp.freq);
+    end
 end
 
 whichZ      = zeros(2,nL);


### PR DESCRIPTION
One-line fix in `private/TerhardtExcitationPatterns.m` (the vectorised version of May 2025). The masked assignment

```matlab
S2(steep < 0) = steep;
```

has agreeing sizes only while the upper excitation slope of every component is negative, which holds up to a component level of about 121 dB SPL at 1 kHz (`0.2*L > 24 + 230/f`). One louder component makes the assignment raise "Unable to perform assignment because the left and right sides have a different number of elements", so the fluctuation strength of very loud signals crashed. The fix masks both sides.

Verified (MATLAB R2026a, 1 kHz AM tone, fmod 4 Hz, md = 1, 2.5 s): at 60 and 90 dB SPL the returned FSmean is identical to 12 decimal places before and after the fix (1.024485900536 and 1.750608940050 vacil); at 125 dB SPL the computation completes where it previously crashed (2.5676 vacil).

Found while reviewing this metric as the structural template for the Daniel & Weber roughness work discussed in #47. The scalar loop of `TerhardtExcitationPatterns_v3.m` guards element-wise and never had the problem.
