### PR TITLE
fix!: correct the Daniel & Weber roughness against the Hermes 2025 reference (refs #47)

### DIFF
--- a/psychoacoustic_metrics/Roughness_Daniel1997/Roughness_Daniel1997.m
+++ b/psychoacoustic_metrics/Roughness_Daniel1997/Roughness_Daniel1997.m
@@ -50,6 +50,13 @@ function OUT = Roughness_Daniel1997(insig,fs,time_skip,show)
 % Author: Gil Felix Greco (2023). Adapted (and verified) for SQAT. 
 % Author: Alejandro Osses, 10/05/2023. Appropriate scaling for the specific roughness.
 % Author: Gil Felix Greco, Braunschweig 16.02.2025 - introduced get_statistics function
+% Author: Sergio Aguirre, 01.09.2026 - corrected the model against the revised
+%   implementation sent by Dik Hermes in 2025 (see issue #47): the upper excitation
+%   slope uses the frequency of the masking component, the g(z) table is the revised
+%   table Hermes derived with that correction, the slope equation uses the exact bin
+%   frequency, the analysis window and the level calibration use the same periodic
+%   Blackman window, and the window length follows the sampling frequency after
+%   resampling.
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 if nargin == 0
@@ -75,16 +82,17 @@ if size(audio,2)~=1 % if the insig is not a [Nx1] array
     audio=audio';   % correct the dimension of the insig
 end
 
-hopsize=N/2; % hopsize is the number of samples hop between successive windows (window length is 8192).
-window = blackman(N);
-
 %% resampling input signal
 
 if ~(fs == 44100 || fs == 40960 || fs == 48000)
     gcd_fs = gcd(48000,fs); % greatest common denominator
     audio = resample(audio,48000/gcd_fs,fs/gcd_fs);
     fs = 48000;
+    N = fs*time_resolution; % window length follows the new sampling frequency
 end
+
+hopsize=N/2; % hopsize is the number of samples hop between successive windows (window length is 8192).
+window = blackman(N,'periodic'); % same window as the level calibration AmpCal below
 
 samples = size(audio,1);
 n = floor((samples-N)/hopsize);
@@ -198,15 +206,20 @@ MinBf = MinExcdB(zb);
 ei    = zeros(47,N);
 Fei   = zeros(47,N);
 
+% g(z) weighting of the specific roughness: revised table that Dik Hermes
+% derived in 2025 together with the correction of the upper excitation slope
+% (CalcGFactors.m of his routines, see issue #47); the 2002 table was tuned
+% around the uncorrected slope. Linear interpolation between the nodes, as in
+% his code.
 gr  = [
-    0 1 2.5 4.9  6.5 8 9 10 11 11.5 13 17.5 21 24
-    0 0.35 0.7 0.7 1.1 1.25 1.26 1.18 1.08 1 0.66 0.46 0.38 0.3
+    0    1    2    3    4    5    6    7    8    9    10   11   12   13   14   15   16   17   18   19   20   21   22   23   24
+    0.15 0.26 0.38 0.47 0.54 0.65 0.76 0.83 0.90 0.98 0.98 0.90 0.80 0.70 0.62 0.54 0.49 0.43 0.39 0.35 0.30 0.30 0.30 0.30 0.30
     ];
 
 gzi    = zeros(1,47);
 h0     = zeros(1,47);
 k      = 1:1:47;
-gzi(k) = sqrt(interp1(gr(1,:)',gr(2,:)',k/2,'spline'));
+gzi(k) = sqrt(interp1(gr(1,:)',gr(2,:)',k/2));
 
 
 % calculate a0
@@ -409,7 +422,7 @@ end
 % BEGIN process window %
 %%%%%%%%%%%%%%%%%%%%%%%%
 
-AmpCal = db2mag(91.2)*2/(N*mean(blackman(N, 'periodic')));
+AmpCal = db2mag(91.2)*2/(N*mean(window));
 %     AmpCal=length(window)/sum(window);
 
 % Calibration between wav-level and loudness-level (assuming
@@ -418,7 +431,7 @@ AmpCal = db2mag(91.2)*2/(N*mean(blackman(N, 'periodic')));
 Chno	=	47;     % number of channels
 Cal	 	=	0.50;   % calibration factor, twice the old value (0.25)
 qb		=	N0:1:Ntop;
-freqs	=	(qb+1)*fs/N;
+freqs	=	(qb-1)*fs/N; % bin q holds the frequency (q-1)*fs/N
 hBPi	=	zeros(Chno,N);
 hBPrms	=	zeros(1,Chno);
 mdept	=	zeros(1,Chno);
@@ -453,8 +466,10 @@ for windowNum = 1:n    %for each frame
     
     for w = 1:1:sizL
         
-        % Steepness of upper slope [dB/Bark] in accordance with Terhardt
-        steep = -24-(230/freqs(w))+(0.2*LdB(whichL(w)));
+        % Steepness of upper slope [dB/Bark] in accordance with Terhardt:
+        % the term 230/f uses the frequency of the masking component itself,
+        % freqs(whichL(w)), as its level LdB(whichL(w)) already did
+        steep = -24-(230/freqs(whichL(w)))+(0.2*LdB(whichL(w)));
         
         if steep < 0
             S2(w) = steep;      % set S2 with steepness value calculated earlier


### PR DESCRIPTION
Implements the model correction discussed in #47, taking the revised implementation Dik Hermes sent to the SQAT team in October 2025 as the reference (MIT licensed per his email, published with his book The Perceptual Structure of Sound, doi: 10.1007/978-3-031-25566-3).

This revision of the PR holds only the correction, applied in place in the existing file: one file, +25 -10. The restructuring into the FluctuationStrength_Osses2016 layout that the first revision carried follows as a separate refactor once this lands; it is prepared and produces identical results.

## The correction

Hermes describes one essential correction in his revised routines: the upper excitation slope of the Terhardt filterbank must use the frequency of the masking component. Our implementation carries the same defect he corrected, inherited from the 2002 code:

```matlab
steep = -24-(230/freqs(w))+(0.2*LdB(whichL(w)));          % current: w counts components
steep = -24-(230/freqs(whichL(w)))+(0.2*LdB(whichL(w)));  % corrected
```

With the counter as index, the term 230/f saw 20 to 40 Hz whatever the component's real frequency, which steepens the upper slope by roughly 10 dB/Bark at 1 kHz. The correction comes paired with the revised g(z) table Hermes derived together with it (his `CalcGFactors.m`, interpolated linearly between the nodes as in his code): the 2002 table was tuned around the defective slope, and applying the slope fix alone moves the 1 asper anchor to 1.27. Two further alignments with negligible effect: the slope equation uses the exact bin frequency (bin q holds (q-1)*fs/N; the code assumed (q+1)*fs/N), and the analysis window and the level calibration now use the same periodic Blackman window.

One further correction, found on the way and unrelated to the model: after resampling to 48 kHz the window length `N` kept the value computed from the input rate, so `N`, the hop size and the window were wrong for any input outside 40960, 44100 and 48000 Hz. They now follow the resampled rate.

## Measured effect (MATLAB R2026a)

Grid: 105 AM tones, seven carriers from 125 Hz to 8 kHz, fifteen modulation frequencies from 20 to 160 Hz, md = 1, 60 dB SPL, 48 kHz. Reference: jury-test data of Fig. 3 of Daniel & Weber (1997), from `1_AM_modulation_freq/reference_values`.

| quantity | before | after |
| --- | --- | --- |
| anchor (1 kHz, 60 dB, fmod 70 Hz), synthetic | 1.000132 | 1.006904 asper |
| anchor, shipped `RefSignal_Roughness_Daniel1997.wav` (as in `ex_Roughness_Daniel1997.m`) | 1.000189 | 1.006905 asper |
| median relative deviation vs Fig. 3 (ref > 0.1 asper) | 13.0% | 9.6% |
| points beyond the 17% JND band | 39 of 94 | 26 of 94 |
| mean RMSE over the seven carriers | 0.056 | 0.047 asper |
| RMSE at 1 kHz | 0.072 | 0.021 asper |
| RMSE at 500 Hz | 0.100 | 0.051 asper |
| RMSE at 2 kHz | 0.042 | 0.106 asper |

Five of the seven carriers improve, and 8 kHz stays within 0.001 asper. The 2 kHz carrier worsens: the corrected model overshoots the jury data around its maximum there, and Hermes' own implementation shares this behaviour (RMSE 0.075 on the same grid at 44.1 kHz). Run point by point against Hermes' code, the corrected implementation agrees within 0.03 asper over the whole grid; his code itself sits at 28 of 93 points beyond the JND band, so the residual disagreement with the 1997 jury data is a property of the model, and the implementation now sits at that ceiling. This also resolves the open question in the README of `1_AM_modulation_freq` about whether the deviations come from the model or from the implementation.

Over the grid, 62 of the 105 values go up and 43 go down; the median absolute move is 0.022 asper and the largest 0.160 asper (500 Hz carrier, fmod 80 Hz, 0.408 to 0.568 asper).

Downstream, the R input of the four psychoacoustic annoyance metrics moves accordingly (PsychoacousticAnnoyance_More2010 verified end to end on the corrected code).

The script that produced the grid numbers is the one proposed in #60; it stays out of this PR.

**Release note.** Roughness_Daniel1997 values change: on AM tones at 60 dB SPL the median move is 0.02 asper and the largest 0.16 asper; the 1 asper reference signal moves from 1.0002 to 1.0069 asper; the R input of the four psychoacoustic annoyance metrics moves accordingly. Inputs outside 40960, 44100 and 48000 Hz were analysed with the wrong window length and change more.
