### PR TITLE
refactor: share the Terhardt filterbank between the modulation metrics (refs #47)

### DIFF
--- a/psychoacoustic_metrics/FluctuationStrength_Osses2016/FluctuationStrength_Osses2016.m
+++ b/psychoacoustic_metrics/FluctuationStrength_Osses2016/FluctuationStrength_Osses2016.m
@@ -187,8 +187,7 @@ for iFrame = nFrames:-1:1
     %     (see model_par.filterbank == 'terhardt', in _debug version):
     
     dBFS = 94; % corresponds to 1 Pa (new default in SQAT)
-    % dBFS = 100; % unit amplitude corresponds to 100 dB (AMT Toolbox 
-                  % convention, default by the original authors)
+
     [ei, ~, ~, clamp] = TerhardtExcitationPatterns(signal,fs,dBFS); % <clamp> requested, so the filterbank does not warn per frame
     if clamp.n > 0
         clampFrames = clampFrames + 1;

--- a/psychoacoustic_metrics/FluctuationStrength_Osses2016/FluctuationStrength_Osses2016.m
+++ b/psychoacoustic_metrics/FluctuationStrength_Osses2016/FluctuationStrength_Osses2016.m
@@ -186,7 +186,7 @@ for iFrame = nFrames:-1:1
     % 2.2 Excitation patterns
     %     (see model_par.filterbank == 'terhardt', in _debug version):
     
-    dBFS = 94; % corresponds to 1 Pa (new default in SQAT)
+    dBFS = 94; % corresponds to 1 Pa (SQAT toolbox convention)
 
     [ei, ~, ~, clamp] = TerhardtExcitationPatterns(signal,fs,dBFS); % <clamp> requested, so the filterbank does not warn per frame
     if clamp.n > 0

--- a/psychoacoustic_metrics/FluctuationStrength_Osses2016/private/TerhardtExcitationPatterns.m
+++ b/psychoacoustic_metrics/FluctuationStrength_Osses2016/private/TerhardtExcitationPatterns.m
@@ -26,7 +26,7 @@ function [ei,ei_f,freq,clamp] = TerhardtExcitationPatterns(insig,fs,dBFS)
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 if nargin < 3
-    dBFS = 100; % AMT toolbox convention
+    dBFS = 94; % AMT toolbox convention
 end
 corr = dBFS + 3;
 

--- a/psychoacoustic_metrics/FluctuationStrength_Osses2016/private/TerhardtExcitationPatterns.m
+++ b/psychoacoustic_metrics/FluctuationStrength_Osses2016/private/TerhardtExcitationPatterns.m
@@ -26,7 +26,7 @@ function [ei,ei_f,freq,clamp] = TerhardtExcitationPatterns(insig,fs,dBFS)
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 if nargin < 3
-    dBFS = 94; % AMT toolbox convention
+    dBFS = 94; % SQAT toolbox convention
 end
 corr = dBFS + 3;
 

--- a/psychoacoustic_metrics/FluctuationStrength_Osses2016/private/TerhardtExcitationPatterns.m
+++ b/psychoacoustic_metrics/FluctuationStrength_Osses2016/private/TerhardtExcitationPatterns.m
@@ -1,9 +1,18 @@
 function [ei,ei_f,freq,clamp] = TerhardtExcitationPatterns(insig,fs,dBFS)
 % function [ei,ei_f,freq,clamp] = TerhardtExcitationPatterns(insig,fs,dBFS)
 %
+% Excitation patterns of one analysis window of the fluctuation strength
+% model: level calibration, transform to the frequency domain and the
+% call to the shared critical-band filterbank of Terhardt, followed by the
+% renormalisation of the summed excitation to the energy of the input. The
+% filterbank itself lives in utilities/Terhardt_filterbank.m, shared with
+% Roughness_Daniel1997; its parameters come from
+% utilities/Terhardt_filterbank_params.m. The a0 transmission factor is
+% applied by the caller, in the time domain (il_PeripheralHearingSystem_t).
+%
 % The optional fourth output <clamp> reports whether the Terhardt upper
-% slope was clamped to zero for any component (see below); when it is
-% requested, no warning is raised here.
+% slope was clamped to zero for any component (see Terhardt_filterbank.m);
+% when it is requested, no warning is raised here.
 %
 % Author: Alejandro Osses, extracted from FluctuationStrength_Osses2016.m on 12/05/2023
 % Modified: Mike Lotinga, May 2025 (parallelised code to omit loop over
@@ -11,7 +20,9 @@ function [ei,ei_f,freq,clamp] = TerhardtExcitationPatterns(insig,fs,dBFS)
 % Modified: Sergio Aguirre, September 2026 (masked both sides of the S2
 % assignment, which crashed above a component level of about 121 dB, and
 % report in <clamp> when the upper slope is clamped to zero, warning only
-% when that output is not requested)
+% when that output is not requested); the filterbank core and its
+% parameter builder moved to the utilities folder, this file keeps the
+% calibration and the renormalisation. Results are bitwise identical
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 if nargin < 3
@@ -22,212 +33,40 @@ corr = dBFS + 3;
 dB2calibrate = rmsdb(insig)+dBFS;
 
 % General parameters
-params = il_calculate_params(insig,fs);
-N01 = params.N01;
-freqs = params.freqs.';
+params = Terhardt_filterbank_params(length(insig),fs);
 
 dfreq = fs/params.N;
-freq = dfreq*(1:params.N); % freqs and freq are the same array, but freqs starts at bin N0
+freq = dfreq*(1:params.N); % params.freqs is the same array, but starts at bin N0
 
 % Transforms input signal to frequency domain
 corr_factor = 10^(corr/20); % il_From_dB(corr)
 insig = corr_factor*fft(insig)/params.N; % 3 dB added to adjust the SPL values to be put into slope equations
 
-% Use only samples that fall into the audible range
-Lg  = abs(insig(params.qb)).';
-LdB = 20*log10(Lg); % il_To_dB(Lg);
+% Shared filterbank (utilities). <info> is requested, so the filterbank does
+% not warn; the warning of this wrapper is below
+if nargout >= 2
+    [ei, info, ei_f] = Terhardt_filterbank(insig, params);
+else
+    [ei, info] = Terhardt_filterbank(insig, params);
+end
+clamp = info.clamp;
 
-% Use only components that are above the hearing threshold
-MinExcdB = params.MinExcdB(:);
-whichL = find(LdB > MinExcdB);
-clamp = struct('n', 0, 'LdB', [], 'freq', []); % Terhardt upper slope clamped to zero: none so far
-
-if isempty(whichL)
-    ei = zeros(params.Chno, params.N);  % Return silence
-    ei_f = zeros(params.Chno, params.N);  % Return silence
+if info.n_components == 0
+    ei_f = zeros(params.Chno, params.N);  % Return silence (ei already is)
     freq = zeros(1, params.N);  % Return silence
     return
 end
 
-nL = length(whichL);
-
-% Steepness of slopes
-S1 = -27;			
-S2 = zeros(nL, 1);
-
-steep = -24 - (230./freqs(whichL)) + (0.2*LdB(whichL));
-% Terhardt's upper slope is defined for steep < 0 only. A component whose
-% level exceeds 120 + 1150/f dB (about 121 dB at 1 kHz) gives steep >= 0,
-% which would mean an excitation that does not decay towards higher
-% frequencies. S2 stays at zero for such a component (flat spread), so the
-% result is an extrapolation outside the range over which the metric was
-% validated (60 to 70 dB SPL); a wrong dBFS is the most likely cause.
-% The clamping is reported in <clamp>: number of components, and level and
-% frequency of the component farthest into the clamped regime. The warning
-% is raised here only when the caller does not request <clamp>, so that a
-% caller running the filterbank once per frame (FluctuationStrength_Osses2016.m)
-% can aggregate the frames and warn once per call.
-clamp.n = nnz(steep >= 0);
-if clamp.n > 0
-    [~, iw] = max(steep);
-    clamp.LdB  = LdB(whichL(iw));
-    clamp.freq = freqs(whichL(iw));
-    if nargout < 4
-        warning('SQAT:FluctuationStrength:TerhardtSlopeClamped', ...
-            ['Terhardt upper slope clamped to zero for %d component(s) whose level ' ...
-             'exceeds 120 + 1150/f dB (highest: %.1f dB at %.0f Hz). The fluctuation ' ...
-             'strength of this frame is an extrapolation outside the range over which ' ...
-             'the metric was validated; check the dBFS calibration.'], ...
-            clamp.n, clamp.LdB, clamp.freq);
-    end
-end
-% Both sides are masked on purpose: this reproduces the element-wise guard
-% of the scalar loop in TerhardtExcitationPatterns_v3.m (S2 stays 0 whenever
-% steep >= 0) and keeps the two sides the same size once any component has
-% steep >= 0. With the right-hand side unmasked the assignment raised a size
-% mismatch error as soon as one component crossed that level.
-S2(steep < 0) = steep(steep < 0);
-S2 = repmat(S2, 1, params.Chno);
-
-whichZ = zeros(nL, 2);
-whichZ(:, 1)	= floor(2*params.Barkno(whichL + N01));
-whichZ(:, 2)	=  ceil(2*params.Barkno(whichL + N01));
-
-% Calculate slopes from steep values
-Slopes = zeros(nL, params.Chno);
-Stemp = Slopes;
-
-Li = repmat(LdB(whichL), 1, params.Chno);
-
-kk = zeros(nL, params.Chno);
-kk1 = kk;
-kk2 = kk;
-delta_z = zeros(nL, params.Chno);
-for l = nL:-1:1    
-    for k = whichZ(l, 1):-1:1
-        kk1(l, k) = k;
-    end
-    for k = params.Chno:-1:whichZ(l, 2)
-        kk2(l, k) = k;
-    end
-end
-
-kk1mask = kk1 > 0;
-kk2mask = kk2 > 0;
-
-kk(kk1mask) = kk1(kk1mask);
-kk(kk2mask) = kk2(kk2mask);
-
-zk = 0.5*(kk);
-zi = repmat(params.Barkno(whichL + N01).', 1, size(zk, 2));
-delta_z(kk1mask) = zi(kk1mask) - zk(kk1mask);
-delta_z(kk2mask) = zk(kk2mask) - zi(kk2mask);
-Stemp(kk1mask) = S1*delta_z(kk1mask) + Li(kk1mask);
-Stemp(kk2mask) = S2(kk2mask).*delta_z(kk2mask) + Li(kk2mask);
-maxk = max(kk, [], 'all');
-MinBfRep = repmat(params.MinBf(1:maxk), nL, 1);
-mask = Stemp > MinBfRep;
-Slopes(mask) = 10.^(Stemp(mask)/20);
-
-% Excitation patterns:
-%   Each frequency having a level above the absolute threshold is looked at.
-%   The contribution of that level (and frequency) onto the other critical
-%   band levels is computed and then assigned.
-ExcAmp  = zeros(max(whichL), params.Chno);
-ei      = zeros(params.Chno, params.N);
-
-for i = params.Chno:-1:1
-    etmp = zeros(1,params.N);
-
-    if i ~= 1
-        ExcAmp(whichL, i) = Slopes(:, i - 1)./Lg(whichL);
-    end
-
-    if i ~= 47
-        mask1 = whichZ(:, 2) > i;
-        ExcAmp(whichL(mask1), i) = Slopes(mask1, i + 1)./Lg(whichL(mask1));
-    end
-
-    mask2 = whichZ(:, 2) == i;
-    ExcAmp(whichL(mask2), i) = 1;
-
-    mask3 = whichZ(:, 1) == i;
-    ExcAmp(whichL(mask3), i) = 1;
-
-    etmp(whichL + N01) = ExcAmp(whichL, i).*insig(whichL + N01).'; % for each level, the level is projected to that in the respective critical band i
-
-    if nargout >= 2
-        ei_f(i,:) = 20*log10(abs(etmp));
-    end
-    ei(i,:) = 2*params.N*real(ifft(etmp)); % figure; plot(To_dB(abs(etmp)),'x','LineWidth',4); xlim([1950 2050])
+if clamp.n > 0 && nargout < 4
+    warning('SQAT:FluctuationStrength:TerhardtSlopeClamped', ...
+        ['Terhardt upper slope clamped to zero for %d component(s) whose level ' ...
+         'exceeds 120 + 1150/f dB (highest: %.1f dB at %.0f Hz). The fluctuation ' ...
+         'strength of this frame is an extrapolation outside the range over which ' ...
+         'the metric was validated; check the dBFS calibration.'], ...
+        clamp.n, clamp.LdB, clamp.freq);
 end
 
 outsig = sum(ei,1);
 gain = dB2calibrate - (rmsdb(outsig)+dBFS);
 gain_factor = 10^(gain/20);
 ei = gain_factor*ei;
-
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-function params = il_calculate_params(x,fs)
-
-params      = struct;
-params.N    = length(x);
-params.Chno = 47;
-
-% Defines audible range indexes and frequencies
-df           = fs/params.N;
-N0           = round(20/df)+1; % start at 20 Hz
-Ntop         = round(20e3/df)+1; % start at 20 kHz
-params.N01   = N0-1;
-params.qb    = N0:Ntop;
-params.freqs = (params.qb-1)*df;
-
-[params.Barkno,Bark_raw] = Get_Bark(params.N,params.qb,params.freqs);
-% Loudness threshold related parameters
-params.MinExcdB = il_calculate_MinExcdB(params.N01,params.qb,params.Barkno);
-params.MinBf    = il_calculate_MinBf(params.N01,df,Bark_raw,params.MinExcdB);
-
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-function MinExcdB = il_calculate_MinExcdB(N01,qb,Barkno)
-
-HTres = [
-    0		130
-    0.01    70
-    0.17    60
-    0.8     30
-    1       25
-    1.5     20
-    2		15
-    3.3     10
-    4		8.1
-    5		6.3
-    6		5
-    8		3.5
-    10		2.5
-    12		1.7
-    13.3	0
-    15		-2.5
-    16		-4
-    17		-3.7
-    18		-1.5
-    19		1.4
-    20		3.8
-    21		5
-    22		7.5
-    23      15
-    24      48
-    24.5 	60
-    25		130
-];
-
-MinExcdB            = zeros(1,length(qb));
-MinExcdB(qb-N01)    = interp1(HTres(:,1),HTres(:,2),Barkno(qb));
-   
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-function MinBf = il_calculate_MinBf(N01,df,Bark,MinExcdB)
-    
-Cf = round(Bark(2:25,2)'/df)-N01+1;
-Bf = round(Bark(1:25,3)'/df)-N01+1;  
-
-zb      = sort([Bf Cf]);
-MinBf   = MinExcdB(zb);

--- a/utilities/Terhardt_filterbank.m
+++ b/utilities/Terhardt_filterbank.m
@@ -1,0 +1,188 @@
+function [ei,info,ei_f] = Terhardt_filterbank(insig_f,params)
+% function [ei,info,ei_f] = Terhardt_filterbank(insig_f,params)
+%
+% Critical-band filterbank with the excitation patterns of Terhardt (1979),
+% as used by the roughness model of Daniel & Weber (1997) and by the
+% fluctuation strength model of Osses et al. (2016). Each spectral component
+% above the hearing threshold is spread over the 47 half-Bark channels with
+% a lower slope of -27 dB/Bark and an upper slope that depends on its level
+% and frequency (Terhardt 1979, Eqs. 4a and 4b); the excitation of each
+% channel is returned in the time domain.
+%
+% This function is shared by FluctuationStrength_Osses2016 (through its
+% wrapper TerhardtExcitationPatterns.m, which applies the a0 transmission
+% factor in the time domain, calibrates and transforms the frame) and, from
+% the rewrite discussed in issue 47 on, by Roughness_Daniel1997 (which
+% applies a0 on the spectrum of the frame, as in the reference code of
+% Hermes). Windowing, calibration, a0 and any renormalisation of the
+% output stay with the caller.
+%
+% INPUT:
+%   insig_f : [1 x N] complex spectrum of one analysis window, with the a0
+%       transmission factor already applied and calibrated so that a
+%       sinusoidal component of L dB SPL has a magnitude of 10^(L/20)
+%   params : struct from Terhardt_filterbank_params.m (N, Chno, N01, qb,
+%       freqs, Barkno, MinExcdB, MinBf)
+%
+% OUTPUT:
+%   ei : [Chno x N] excitation pattern of each channel in the time domain,
+%       scaled as 2*N*real(ifft(.)); the scale cancels in the modulation
+%       depth of both metrics
+%   info : struct with
+%       n_components : number of spectral components above the hearing
+%           threshold (zero means the window is silent and ei is all zeros)
+%       clamp : struct (n, LdB, freq) reporting how many components had
+%           the upper slope clamped to zero, and the level and frequency of
+%           the one farthest into the clamped regime (see below). A warning
+%           is raised here only when <info> is not requested, so that a
+%           caller running the filterbank once per frame can aggregate the
+%           frames and warn once per call
+%   ei_f : [Chno x N] level, in dB, of the excitation pattern of each
+%       channel in the frequency domain (for inspection only)
+%
+% Author: Dik Hermes, TU/e (2000-2005), original implementation of the
+%   Daniel & Weber model
+% Author: Alejandro Osses, HTI, TU/e, the Netherlands, 2014-2016; extracted
+%   from FluctuationStrength_Osses2016.m on 12/05/2023
+% Modified: Mike Lotinga, May 2025 (parallelised code to omit loop over
+%   whichL for improved performance)
+% Modified: Sergio Aguirre, September 2026 (masked both sides of the S2
+%   assignment, which crashed above a component level of about 121 dB;
+%   report the clamping in <info>); moved to the utilities folder as the
+%   filterbank shared by the two modulation metrics, with the spectrum as
+%   input. The arithmetic is unchanged: FluctuationStrength_Osses2016
+%   returns bitwise identical results
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+N01   = params.N01;
+freqs = params.freqs.';
+
+% Use only samples that fall into the audible range
+Lg  = abs(insig_f(params.qb)).';
+LdB = 20*log10(Lg); % il_To_dB(Lg);
+
+% Use only components that are above the hearing threshold
+MinExcdB = params.MinExcdB(:);
+whichL = find(LdB > MinExcdB);
+info = struct('n_components', numel(whichL), ...
+              'clamp', struct('n', 0, 'LdB', [], 'freq', [])); % Terhardt upper slope clamped to zero: none so far
+
+if isempty(whichL)
+    ei = zeros(params.Chno, params.N);  % Return silence
+    ei_f = zeros(params.Chno, params.N);  % Return silence
+    return
+end
+
+nL = length(whichL);
+
+% Steepness of slopes
+S1 = -27;			
+S2 = zeros(nL, 1);
+
+steep = -24 - (230./freqs(whichL)) + (0.2*LdB(whichL));
+% Terhardt's upper slope is defined for steep < 0 only. A component whose
+% level exceeds 120 + 1150/f dB (about 121 dB at 1 kHz) gives steep >= 0,
+% which would mean an excitation that does not decay towards higher
+% frequencies. S2 stays at zero for such a component (flat spread), so the
+% result is an extrapolation outside the range over which the metric was
+% validated (60 to 70 dB SPL); a wrong dBFS is the most likely cause.
+% The clamping is reported in <clamp>: number of components, and level and
+% frequency of the component farthest into the clamped regime. The warning
+% is raised here only when the caller does not request <info>, so that a
+% caller running the filterbank once per frame (the wrapper of the
+% fluctuation strength, the frame loop of the roughness) can aggregate the
+% frames and warn once per call.
+info.clamp.n = nnz(steep >= 0);
+if info.clamp.n > 0
+    [~, iw] = max(steep);
+    info.clamp.LdB  = LdB(whichL(iw));
+    info.clamp.freq = freqs(whichL(iw));
+    if nargout < 2
+        warning('SQAT:Terhardt_filterbank:SlopeClamped', ...
+            ['Terhardt upper slope clamped to zero for %d component(s) whose level ' ...
+             'exceeds 120 + 1150/f dB (highest: %.1f dB at %.0f Hz). The excitation ' ...
+             'of this window is an extrapolation outside the range over which the ' ...
+             'model was validated; check the dBFS calibration.'], ...
+            info.clamp.n, info.clamp.LdB, info.clamp.freq);
+    end
+end
+% Both sides are masked on purpose: this reproduces the element-wise guard
+% of the scalar loop in TerhardtExcitationPatterns_v3.m (S2 stays 0 whenever
+% steep >= 0) and keeps the two sides the same size once any component has
+% steep >= 0. With the right-hand side unmasked the assignment raised a size
+% mismatch error as soon as one component crossed that level.
+S2(steep < 0) = steep(steep < 0);
+S2 = repmat(S2, 1, params.Chno);
+
+whichZ = zeros(nL, 2);
+whichZ(:, 1)	= floor(2*params.Barkno(whichL + N01));
+whichZ(:, 2)	=  ceil(2*params.Barkno(whichL + N01));
+
+% Calculate slopes from steep values
+Slopes = zeros(nL, params.Chno);
+Stemp = Slopes;
+
+Li = repmat(LdB(whichL), 1, params.Chno);
+
+kk = zeros(nL, params.Chno);
+kk1 = kk;
+kk2 = kk;
+delta_z = zeros(nL, params.Chno);
+for l = nL:-1:1    
+    for k = whichZ(l, 1):-1:1
+        kk1(l, k) = k;
+    end
+    for k = params.Chno:-1:whichZ(l, 2)
+        kk2(l, k) = k;
+    end
+end
+
+kk1mask = kk1 > 0;
+kk2mask = kk2 > 0;
+
+kk(kk1mask) = kk1(kk1mask);
+kk(kk2mask) = kk2(kk2mask);
+
+zk = 0.5*(kk);
+zi = repmat(params.Barkno(whichL + N01).', 1, size(zk, 2));
+delta_z(kk1mask) = zi(kk1mask) - zk(kk1mask);
+delta_z(kk2mask) = zk(kk2mask) - zi(kk2mask);
+Stemp(kk1mask) = S1*delta_z(kk1mask) + Li(kk1mask);
+Stemp(kk2mask) = S2(kk2mask).*delta_z(kk2mask) + Li(kk2mask);
+maxk = max(kk, [], 'all');
+MinBfRep = repmat(params.MinBf(1:maxk), nL, 1);
+mask = Stemp > MinBfRep;
+Slopes(mask) = 10.^(Stemp(mask)/20);
+
+% Excitation patterns:
+%   Each frequency having a level above the absolute threshold is looked at.
+%   The contribution of that level (and frequency) onto the other critical
+%   band levels is computed and then assigned.
+ExcAmp  = zeros(max(whichL), params.Chno);
+ei      = zeros(params.Chno, params.N);
+
+for i = params.Chno:-1:1
+    etmp = zeros(1,params.N);
+
+    if i ~= 1
+        ExcAmp(whichL, i) = Slopes(:, i - 1)./Lg(whichL);
+    end
+
+    if i ~= 47
+        mask1 = whichZ(:, 2) > i;
+        ExcAmp(whichL(mask1), i) = Slopes(mask1, i + 1)./Lg(whichL(mask1));
+    end
+
+    mask2 = whichZ(:, 2) == i;
+    ExcAmp(whichL(mask2), i) = 1;
+
+    mask3 = whichZ(:, 1) == i;
+    ExcAmp(whichL(mask3), i) = 1;
+
+    etmp(whichL + N01) = ExcAmp(whichL, i).*insig_f(whichL + N01).'; % for each level, the level is projected to that in the respective critical band i
+
+    if nargout >= 3
+        ei_f(i,:) = 20*log10(abs(etmp));
+    end
+    ei(i,:) = 2*params.N*real(ifft(etmp)); % figure; plot(To_dB(abs(etmp)),'x','LineWidth',4); xlim([1950 2050])
+end

--- a/utilities/Terhardt_filterbank_params.m
+++ b/utilities/Terhardt_filterbank_params.m
@@ -1,0 +1,90 @@
+function params = Terhardt_filterbank_params(N,fs)
+% function params = Terhardt_filterbank_params(N,fs)
+%
+% Parameters of the Terhardt critical-band filterbank (see
+% Terhardt_filterbank.m) for an analysis window of N samples at the sampling
+% frequency fs. The fields are:
+%
+%   N        : window length in samples
+%   Chno     : number of half-Bark channels (47)
+%   N01      : index offset of the audible range, so that bin q of the
+%              spectrum corresponds to element q-N01 of the range vectors
+%   qb       : bins of the audible range, 20 Hz to 20 kHz
+%   freqs    : frequency of each bin of qb, (qb-1)*fs/N
+%   Barkno   : critical-band rate of each bin (see Get_Bark.m)
+%   MinExcdB : hearing threshold, in dB, at each bin of qb
+%   MinBf    : hearing threshold at the critical-band edges and centres
+%
+% This function is shared by FluctuationStrength_Osses2016 (through
+% TerhardtExcitationPatterns.m) and, from the rewrite discussed in issue 47
+% on, by Roughness_Daniel1997.
+%
+% Author: Alejandro Osses, HTI, TU/e, the Netherlands, 2014-2016, as the local
+%   functions il_calculate_params, il_calculate_MinExcdB and il_calculate_MinBf
+%   of TerhardtExcitationPatterns.m (FluctuationStrength_Osses2016)
+% Author: Sergio Aguirre, September 2026 - moved to the utilities folder
+%   unchanged, so that both modulation metrics build the same parameters
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+
+params      = struct;
+params.N    = N;
+params.Chno = 47;
+
+% Defines audible range indexes and frequencies
+df           = fs/params.N;
+N0           = round(20/df)+1; % start at 20 Hz
+Ntop         = round(20e3/df)+1; % start at 20 kHz
+params.N01   = N0-1;
+params.qb    = N0:Ntop;
+params.freqs = (params.qb-1)*df;
+
+[params.Barkno,Bark_raw] = Get_Bark(params.N,params.qb,params.freqs);
+% Loudness threshold related parameters
+params.MinExcdB = il_calculate_MinExcdB(params.N01,params.qb,params.Barkno);
+params.MinBf    = il_calculate_MinBf(params.N01,df,Bark_raw,params.MinExcdB);
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+function MinExcdB = il_calculate_MinExcdB(N01,qb,Barkno)
+
+HTres = [
+    0		130
+    0.01    70
+    0.17    60
+    0.8     30
+    1       25
+    1.5     20
+    2		15
+    3.3     10
+    4		8.1
+    5		6.3
+    6		5
+    8		3.5
+    10		2.5
+    12		1.7
+    13.3	0
+    15		-2.5
+    16		-4
+    17		-3.7
+    18		-1.5
+    19		1.4
+    20		3.8
+    21		5
+    22		7.5
+    23      15
+    24      48
+    24.5 	60
+    25		130
+];
+
+MinExcdB            = zeros(1,length(qb));
+MinExcdB(qb-N01)    = interp1(HTres(:,1),HTres(:,2),Barkno(qb));
+   
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+function MinBf = il_calculate_MinBf(N01,df,Bark,MinExcdB)
+    
+Cf = round(Bark(2:25,2)'/df)-N01+1;
+Bf = round(Bark(1:25,3)'/df)-N01+1;  
+
+zb      = sort([Bf Cf]);
+MinBf   = MinExcdB(zb);

--- a/utilities/Terhardt_filterbank_params.m
+++ b/utilities/Terhardt_filterbank_params.m
@@ -26,7 +26,6 @@ function params = Terhardt_filterbank_params(N,fs)
 %   unchanged, so that both modulation metrics build the same parameters
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-
 params      = struct;
 params.N    = N;
 params.Chno = 47;
@@ -40,6 +39,7 @@ params.qb    = N0:Ntop;
 params.freqs = (params.qb-1)*df;
 
 [params.Barkno,Bark_raw] = Get_Bark(params.N,params.qb,params.freqs);
+
 % Loudness threshold related parameters
 params.MinExcdB = il_calculate_MinExcdB(params.N01,params.qb,params.Barkno);
 params.MinBf    = il_calculate_MinBf(params.N01,df,Bark_raw,params.MinExcdB);


### PR DESCRIPTION
Second step of the roughness work discussed in #47, as agreed: the Terhardt filterbank becomes a shared function before the roughness is rewritten on it. This PR changes the structure only; results are bitwise identical.

**What moves.** `utilities/Terhardt_filterbank.m` holds the critical-band filterbank (the vectorised code of `TerhardtExcitationPatterns.m`, unchanged in its arithmetic) and `utilities/Terhardt_filterbank_params.m` holds its parameter builder (the former local functions `il_calculate_params`, `il_calculate_MinExcdB` and `il_calculate_MinBf`, unchanged). The shared function takes the spectrum of one analysis window with the a0 transmission factor already applied, the same approach as in the reference code of Hermes and in the current roughness (`a0.*fft(TempIn)`); windowing, calibration, a0 and any renormalisation stay with the caller. A second output `info` reports the number of components above threshold and the slope clamping; the function warns only when `info` is not requested, so a caller running it once per frame can warn once per call, as in #59.

**What stays.** `TerhardtExcitationPatterns.m` in the fluctuation strength folder becomes a thin wrapper: calibration, FFT, the shared call and the renormalisation of the summed excitation to the input energy. Same signature, same four outputs, same warning identifier, and `FluctuationStrength_Osses2016.m` is untouched. `TerhardtExcitationPatterns_v3.m` (scalar reference) stays in place, since `pub_Osses2023c` calls it from that folder. `Roughness_Daniel1997` is not changed here; it starts using the shared function in the rewrite (PR 3).

**Verification (MATLAB R2026a, against `main`).** `FluctuationStrength_Osses2016` returns bitwise identical output structs, every field, for eleven signals: 1 kHz AM tones (fmod 4 Hz, md 1) at 0, 60, 70 and 125 dB SPL with method 0 and 1, a 250 Hz AM tone (fmod 8 Hz, md 0.5) at 70 dB, an FM tone (1.5 kHz, fmod 4 Hz, 700 Hz deviation) at 70 dB, a 4 kHz AM tone at 90 dB, white noise at 60 dB, and a 44.1 kHz input at 50 dB. The warning counts are identical (one per call at 125 dB SPL, none otherwise). Called directly with one to four outputs the wrapper returns bitwise identical `ei`, `ei_f`, `freq` and `clamp`, including the silence path. The two example scripts of the fluctuation strength print identical results. `Roughness_Daniel1997` is bitwise identical as well. `checkcode` reports nothing on the three files.
