### PR TITLE
fix: let the peak criterion of Tonality_Aures1985 reach the lower edge of the range

### DIFF
--- a/psychoacoustic_metrics/Tonality_Aures1985/Tonality_Aures1985.m
+++ b/psychoacoustic_metrics/Tonality_Aures1985/Tonality_Aures1985.m
@@ -157,15 +157,25 @@ for iFrame = 1:nFrames
     ToneIdx = zeros(length(SPLcrop),1); % initialize vector, tonal components idx
     k = 1; % initialize counter
     
-    % find tones...
-    for i = (k3+1):(length(SPLcrop)-k3)
+    % find tones... The bins the criterion compares with are read from the
+    % full spectrum, so that a tone near the lower edge of the range still has
+    % neighbours below it: with the distances in hertz the criterion reaches
+    % 37.5 Hz down, and read from the cropped vector alone it could not fire
+    % below 57.5 Hz.
+    for i = 1:length(SPLcrop)
         
-        if SPLcrop(i) > SPLcrop(i-1) && ... % first condition
-           SPLcrop(i) >= SPLcrop(i+1) && ...
-           SPLcrop(i) - SPLcrop(i-k3) >= threshold && ... % second condition
-           SPLcrop(i) - SPLcrop(i-k2) >= threshold && ...
-           SPLcrop(i) - SPLcrop(i+k2) >= threshold && ...
-           SPLcrop(i) - SPLcrop(i+k3) >= threshold
+        j = i + MinFrequencyindex - 1; % index of the same bin on the full spectrum
+        
+        if j-k3 < 1 || j+k3 > length(SPL)
+            continue
+        end
+        
+        if SPL(j) > SPL(j-1) && ... % first condition
+           SPL(j) >= SPL(j+1) && ...
+           SPL(j) - SPL(j-k3) >= threshold && ... % second condition
+           SPL(j) - SPL(j-k2) >= threshold && ...
+           SPL(j) - SPL(j+k2) >= threshold && ...
+           SPL(j) - SPL(j+k3) >= threshold
             
            ToneIdx(k) = i; % get the idx of the tones on Lcrop
            k = k+1;


### PR DESCRIPTION
Follow-up to #68, tracked in #67.

#68 expressed the distances of the criterion of Terhardt in hertz, 25 and 37.5 Hz, so that they stay put when the analysis window changes. The loop that applies the criterion read its neighbours from the cropped vector, which starts at 20 Hz, and skipped the first 37.5 Hz of it for lack of neighbours below. A tone of 50 Hz at 70 dB SPL went from 0.61 t.u. before #68 to 0.00 t.u.

The neighbours are read from the full spectrum now, which holds the bins below 20 Hz, so the criterion fires from 36 Hz upwards, the same reach the original grid of 6.25 Hz gave with three bins.

## Measured

- 40 Hz: 0.56 t.u.; 50 Hz: 0.62 t.u.; from 60 Hz upwards every value is identical to main.
- Anchor 1.0000 t.u. at both sampling rates.
- The three verification scripts of `validation/Tonality_Aures1985` return the same numbers as on main, and the figures do not move.

## Blast radius

Only signals with tonal components between 36 and 57 Hz change. `PsychoacousticAnnoyance_More2010` and `PsychoacousticAnnoyance_Di2016` consume this metric.
